### PR TITLE
Added --version flags to trace and boostrap commands

### DIFF
--- a/splunk_otel/cmd/bootstrap.py
+++ b/splunk_otel/cmd/bootstrap.py
@@ -8,6 +8,7 @@ from opentelemetry.instrumentation import bootstrap
 from opentelemetry.instrumentation.version import __version__ as otel_version
 
 from splunk_otel import symbols
+from splunk_otel.version import format_version_info
 
 logger = getLogger(__file__)
 
@@ -162,6 +163,14 @@ def run() -> None:
         """
     )
     parser.add_argument(
+        "--version",
+        "-v",
+        required=False,
+        action="store_true",
+        dest="version",
+        help="Print version information",
+    )
+    parser.add_argument(
         "-a",
         "--action",
         choices=[
@@ -188,6 +197,10 @@ def run() -> None:
         """,
     )
     args = parser.parse_args()
+
+    if args.version:
+        print(format_version_info())
+        return
 
     cmd = {
         action_install: _run_install,

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -53,7 +53,7 @@ def init_tracer(url=None, service_name=None):
         resource=Resource.create(
             attributes={
                 "service.name": service_name,
-                "splunk.distro.version": __version__,
+                "telemetry.auto.version": __version__,
             }
         )
     )

--- a/splunk_otel/version.py
+++ b/splunk_otel/version.py
@@ -14,4 +14,19 @@
 
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("splunk-opentelemetry").version
+pkg = pkg_resources.get_distribution("splunk-opentelemetry")
+
+__version__ = pkg.version
+
+
+def format_version_info():
+    lines = []
+    lines.append('splunk-opentelemetry=={0}'.format(pkg.version))
+    lines.append('\n\nAlso uses the following OpenTelemetry libraries:\n')
+    for dep in pkg.requires():
+      if 'opentelemetry' in dep.name:
+        lines.append('\t{0}'.format(str(dep)))
+
+    return '\n'.join(lines)
+    
+    


### PR DESCRIPTION
The --version flag makes the command print version information that
looks like the following:

```
splunk-opentelemetry==0.1.8

Also uses the following OpenTelemetry libraries:

	opentelemetry-api==0.*,>=0.14.0.b0
	opentelemetry-exporter-zipkin==0.*,>=0.14.0.b0
	opentelemetry-instrumentation==0.*,>=0.14.0.b0
	opentelemetry-sdk==0.*,>=0.14.0.b0
```

Also replaces `splunk.distro.version` resource attribute with `telemetry.auto.version`.