### PR TITLE
Mark 3.6 as least supported version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ splk-py-trace = 'splunk_otel.cmd.trace:run'
 splk-py-trace-bootstrap = 'splunk_otel.cmd.bootstrap:run'
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 opentelemetry-api = "1.0.0rc1"
 opentelemetry-sdk = "1.0.0rc1"
 opentelemetry-exporter-jaeger = "1.0.0rc1"


### PR DESCRIPTION
We support Python 3.6+ only but the packaging hinted at 3.5+ instead of
3.6+. This commit corrects the packaging to mark 3.6 as the oldest
supported version.