### PR TITLE
Allow specifying more config options when instrumenting with code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `init_tracing()` now accepts an argument called `endpoint` instead of `url`.
 - `SPLUNK_TRACE_EXPORTER_URL` was replaced with `OTEL_EXPORTER_JAEGER_ENDPOINT`.
+- `start_tracing` now accepts `access_token` and `max_attr_length` options.
 
 ## 0.9.0 (03-13-2021)
 

--- a/splunk_otel/options.py
+++ b/splunk_otel/options.py
@@ -19,7 +19,51 @@ from typing import Optional
 logger = logging.getLogger("options")
 
 
-def from_env(name: str, default: Optional[str] = None) -> Optional[str]:
+DEFAULT_SERVICE_NAME = "unnamed-python-service"
+DEFAULT_ENDPOINT = "http://localhost:9080/v1/trace"
+DEFAULT_MAX_ATTR_LENGTH = 1200
+
+
+class Options:
+    endpoint: str
+    service_name: str
+    access_token: str
+    max_attr_length: int
+
+    def __init__(
+        self,
+        service_name: str = None,
+        endpoint: str = None,
+        access_token: str = None,
+        max_attr_length: int = None,
+    ):
+        if not endpoint:
+            endpoint = environ.get("OTEL_EXPORTER_JAEGER_ENDPOINT", None)
+            if not endpoint:
+                endpoint = splunk_env_var("TRACE_EXPORTER_URL")
+                if endpoint:
+                    logger.warning(
+                        "%s is deprecated and will be removed soon. Please use %s instead",
+                        "SPLUNK_TRACE_EXPORTER_URL",
+                        "OTEL_EXPORTER_JAEGER_ENDPOINT",
+                    )
+            endpoint = endpoint or DEFAULT_ENDPOINT
+        self.endpoint = endpoint
+
+        if not service_name:
+            service_name = splunk_env_var("SERVICE_NAME", DEFAULT_ENDPOINT)
+        self.service_name = service_name
+
+        if not access_token:
+            access_token = splunk_env_var("ACCESS_TOKEN", None)
+        self.access_token = service_name
+
+        if not max_attr_length:
+            max_attr_length = splunk_env_var("MAX_ATTR_LENGTH", DEFAULT_MAX_ATTR_LENGTH)
+        self.max_attr_length = max_attr_length
+
+
+def splunk_env_var(name: str, default: Optional[str] = None) -> Optional[str]:
     old_key = "SPLK_{0}".format(name)
     new_key = "SPLUNK_{0}".format(name)
     if old_key in environ:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -16,7 +16,7 @@ import logging
 import os
 from unittest import TestCase, mock
 
-from splunk_otel.options import from_env
+from splunk_otel.options import splunk_env_var
 
 
 class TestOptions(TestCase):
@@ -24,13 +24,13 @@ class TestOptions(TestCase):
         os.environ, {"SPLK_OLD_VAR": "OLD_VALUE", "SPLUNK_NEW_VAR": "NEW_VALUE"}
     )
     def test_from_env(self):
-        self.assertIsNone(from_env("TEST_VAR1"))
-        self.assertEqual(from_env("TEST_VAR1", "default value"), "default value")
+        self.assertIsNone(splunk_env_var("TEST_VAR1"))
+        self.assertEqual(splunk_env_var("TEST_VAR1", "default value"), "default value")
 
         with self.assertLogs(level=logging.WARNING) as warning:
-            self.assertEqual(from_env("OLD_VAR"), "OLD_VALUE")
+            self.assertEqual(splunk_env_var("OLD_VAR"), "OLD_VALUE")
             self.assertIn(
                 "SPLK_OLD_VAR is deprecated and will be removed soon. Please use SPLUNK_OLD_VAR instead",
                 warning.output[0],
             )
-        self.assertEqual(from_env("NEW_VAR"), "NEW_VALUE")
+        self.assertEqual(splunk_env_var("NEW_VAR"), "NEW_VALUE")


### PR DESCRIPTION
First step of many to make splunk-otel-py consistent with splunk-otel-js