### PR TITLE
Use circleci contexts for secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,8 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - release:
+          context:
+            - signalfx-pypi-password
           requires:
             - build 
             - lint


### PR DESCRIPTION
Use CircleCI contexts in the publish job. This ensures only the publish job will have access to auth tokens needed to publish packages.