### PR TITLE
Remove service_name and SPLUNK_SERVICE_NAME config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- Added `resource_attributes` config option to the `splunk_otel.start_tracing()` function.
+  [#57](https://github.com/signalfx/splunk-otel-python/pull/57)
+
+### Removed 
+
+- Removed `service_name` config option from the `splunk_otel.start_tracing()` function.
+  Please pass `resource_attributes={'service.name': 'my-service-name'}` to the function instead.
+  [#57](https://github.com/signalfx/splunk-otel-python/pull/57)
+
+- Removed support for `SPLUNK_SERVICE_NAME` environment variable.
+  Please use `OTEL_RESOURCE_ATTRIBTES=service.name=<my-service-name>` instead.
+  [#57](https://github.com/signalfx/splunk-otel-python/pull/57)
+
 ## 0.12.0 (04-21-2021)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then the runtime parameters should be updated to:
 ```
 $ pip install splunk-opentelemetry
 $ splk-py-trace-bootstrap
-$ SPLUNK_SERVICE_NAME=my-python-app \
+$ OTEL_RESOURCE_ATTRIBUTES=service.name=my-python-app \
     splk-py-trace python main.py --port=8000
 ```
 
@@ -93,11 +93,10 @@ To see the Python instrumentation in action with sample applications, see our
 | Environment variable          | Config Option                        | Default value                        | Notes                                                                  |
 | ----------------------------- | ------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------- |
 | OTEL_EXPORTER_JAEGER_ENDPOINT | endpoint                             | `http://localhost:9080/v1/trace`     | The jaeger endpoint to connect to. Currently only HTTP is supported.   |
-| SPLUNK_SERVICE_NAME           | service_name                       | `unnamed-python-service`             | The service name of this Python application.                                 |
 | SPLUNK_ACCESS_TOKEN          | access_token |      | The optional organization access token for trace submission requests.  |
 | SPLUNK_MAX_ATTR_LENGTH       | max_attr_length | 1200            | Maximum length of string attribute value in characters. Longer values are truncated.                                                                                                                                                                                                                                                                                                                      |
 | SPLUNK_TRACE_RESPONSE_HEADER_ENABLED | trace_response_header_enabled | True | Enables adding server trace information to HTTP response headers. |
-| OTEL_RESOURCE_ATTRIBUTES      |            | unset          | Comma-separated list of resource attributes added to every reported span. <details><summary>Example</summary>`key1=val1,key2=val2`</details>
+| OTEL_RESOURCE_ATTRIBUTES      |            | unset          | Comma-separated list of resource attributes added to every reported span. <details><summary>Example</summary>`service.name=my-python-service,service.version=3.1,deployment.environment=production`</details>
 | OTEL_TRACE_ENABLED            |            | `true`         | Globally enables tracer creation and auto-instrumentation.                                                                                                                                                                                                                                                                                                                                                |
 
 ## Advanced Getting Started
@@ -135,8 +134,17 @@ from splunk_otel.tracing import start_tracing
 
 start_tracing()
 
-# also accepts config options
-# start_tracing(endpoint='http://localhost:9080/v1/trace, service_name='unnamed-python-service')
+# Also accepts config options:
+# start_tracing(
+#   endpoint='http://localhost:9080/v1/trace,
+#   access_token='',
+#   max_attr_length=1200,
+#   trace_response_header_enabled=True,
+#   resource_attributes={
+#    'service.name': 'my-python-service',
+#    'service.version': '3.1',
+#    'deployment.environment': 'production',
+#  })
 
 # rest of your python application's entrypoint script
 ```

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -50,7 +50,10 @@ class TestJaegerExporter(unittest.TestCase):
 
     def test_exporter_uses_collector_not_udp_agent(self):
         exporter = _new_jaeger_exporter(
-            Options(endpoint=self.endpoint, service_name=self.service_name)
+            Options(
+                endpoint=self.endpoint,
+                resource_attributes={"service.name": self.service_name},
+            )
         )
         agent_client_mock = mock.Mock(spec=jaeger_exporter.AgentClientUDP)
         exporter._agent_client = agent_client_mock  # pylint:disable=protected-access
@@ -63,7 +66,10 @@ class TestJaegerExporter(unittest.TestCase):
 
     def test_http_export(self):
         exporter = _new_jaeger_exporter(
-            Options(endpoint=self.endpoint, service_name=self.service_name)
+            Options(
+                endpoint=self.endpoint,
+                resource_attributes={"service.name": self.service_name},
+            )
         )
         exporter.export((self._test_span,))
 
@@ -79,8 +85,8 @@ class TestJaegerExporter(unittest.TestCase):
         exporter = _new_jaeger_exporter(
             Options(
                 endpoint=self.endpoint,
-                service_name=self.service_name,
                 access_token=access_token,
+                resource_attributes={"service.name": self.service_name},
             )
         )
         exporter.export((self._test_span,))

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -16,7 +16,7 @@ import logging
 import os
 from unittest import TestCase, mock
 
-from splunk_otel.options import splunk_env_var
+from splunk_otel.options import Options, splunk_env_var
 
 
 class TestOptions(TestCase):
@@ -34,3 +34,30 @@ class TestOptions(TestCase):
                 warning.output[0],
             )
         self.assertEqual(splunk_env_var("NEW_VAR"), "NEW_VALUE")
+
+    def test_default_service_name(self):
+        options = Options()
+        self.assertIsInstance(options.resource_attributes, dict)
+        self.assertEqual(
+            options.resource_attributes["service.name"], "unnamed-python-service"
+        )
+
+    def test_service_name_from_kwargs(self):
+        options = Options(
+            resource_attributes={"service.name": "test service name from kwargs"}
+        )
+        self.assertIsInstance(options.resource_attributes, dict)
+        self.assertEqual(
+            options.resource_attributes["service.name"], "test service name from kwargs"
+        )
+
+    @mock.patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "service.name=test service name from env"},
+    )
+    def test_service_name_from_env(self):
+        options = Options()
+        self.assertIsInstance(options.resource_attributes, dict)
+        self.assertEqual(
+            options.resource_attributes["service.name"], "test service name from env"
+        )


### PR DESCRIPTION
# Description

Removing explicit config options for service name as suggested by the GDI spec.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added/updated
- [x] Documentation has been updated
