### PR TITLE
Use tracecontext and baggage as default trace propagators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@
 - Removed `service_name` config option from the `splunk_otel.start_tracing()` function.
   Please pass `resource_attributes={'service.name': 'my-service-name'}` to the function instead.
   [#57](https://github.com/signalfx/splunk-otel-python/pull/57)
-
 - Removed support for `SPLUNK_SERVICE_NAME` environment variable.
   Please use `OTEL_RESOURCE_ATTRIBTES=service.name=<my-service-name>` instead.
   [#57](https://github.com/signalfx/splunk-otel-python/pull/57)
+- Removed `opentelemetry-propagator-b3` as a depedency. It can be installed direclty or by using
+  the new `b3` extras options e.g, `pip install splunk-opentelemetry[b3]`.
+  [#58](https://github.com/signalfx/splunk-otel-python/pull/58)
+
+### Changed 
+
+- Changed default trace propagators to W3C trace context and W3C baggage.
+  [#58](https://github.com/signalfx/splunk-otel-python/pull/58)
 
 ## 0.12.0 (04-21-2021)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,12 @@ splunk_distro = "splunk_otel.distro:SplunkDistro"
 python = "^3.6"
 opentelemetry-api = "^1.1.0"
 opentelemetry-sdk = "^1.1.0"
-opentelemetry-propagator-b3 = "^1.1.0"
 opentelemetry-exporter-jaeger-thrift = "^1.1.0"
 opentelemetry-instrumentation = "0.20b0"
+opentelemetry-propagator-b3 = {version = "^1.1.0", optional = true} 
+
+[tool.poetry.extras]
+b3 = ["opentelemetry-propagator-b3"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.1"

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -19,10 +19,9 @@ from functools import partial
 from typing import Any, Dict, Optional, Union
 
 from opentelemetry import environment_variables as otel_env_vars
-from opentelemetry import propagate, trace
+from opentelemetry import trace
 from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.instrumentation.propagators import set_global_response_propagator
-from opentelemetry.propagators.b3 import B3Format
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -58,7 +57,6 @@ def _configure_tracing(options: Options) -> None:
     provider = TracerProvider(
         resource=Resource.create(attributes=options.resource_attributes)
     )
-    propagate.set_global_textmap(B3Format())
     if options.response_propagation:
         set_global_response_propagator(ServerTimingResponsePropagator())  # type: ignore
 


### PR DESCRIPTION
# Description

Use tracecontext and baggage as default trace propagators as recommended by the GDI spec.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added/updated
- [x] Documentation has been updated
