### PR TITLE
Remove support for old SPLK_ prefixed env vars

### DIFF
--- a/splunk_otel/environment_variables.py
+++ b/splunk_otel/environment_variables.py
@@ -1,0 +1,19 @@
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SPLUNK_ACCESS_TOKEN = "SPLUNK_ACCESS_TOKEN"
+SPLUNK_TRACE_EXPORTER_URL = "SPLUNK_TRACE_EXPORTER_URL"
+SPLUNK_MAX_ATTR_LENGTH = "SPLUNK_MAX_ATTR_LENGTH"
+SPLUNK_TRACE_RESPONSE_HEADER_ENABLED = "SPLUNK_TRACE_RESPONSE_HEADER_ENABLED"
+SPLUNK_SERVICE_NAME = "SPLUNK_SERVICE_NAME"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -12,31 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 from unittest import TestCase, mock
 
 from opentelemetry.sdk.resources import Resource
 
-from splunk_otel.options import Options, splunk_env_var
+from splunk_otel.options import Options
 
 
 class TestOptions(TestCase):
-    @mock.patch.dict(
-        os.environ, {"SPLK_OLD_VAR": "OLD_VALUE", "SPLUNK_NEW_VAR": "NEW_VALUE"}
-    )
-    def test_from_env(self):
-        self.assertIsNone(splunk_env_var("TEST_VAR1"))
-        self.assertEqual(splunk_env_var("TEST_VAR1", "default value"), "default value")
-
-        with self.assertLogs(level=logging.WARNING) as warning:
-            self.assertEqual(splunk_env_var("OLD_VAR"), "OLD_VALUE")
-            self.assertIn(
-                "SPLK_OLD_VAR is deprecated and will be removed soon. Please use SPLUNK_OLD_VAR instead",
-                warning.output[0],
-            )
-        self.assertEqual(splunk_env_var("NEW_VAR"), "NEW_VALUE")
-
     def test_default_service_name(self):
         options = Options()
         self.assertIsInstance(options.resource, Resource)


### PR DESCRIPTION
# Description

Removed support for old `SPLK_` prefixed env vars in preparation for 1.0


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
