### PR TITLE
Use opentelemetry-instrumentation "agent" version for telemetry.auto.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - Changed default trace propagators to W3C trace context and W3C baggage.
   [#58](https://github.com/signalfx/splunk-otel-python/pull/58)
+- `telemetry.auto.version` will now correctly refer to `opentelemetry-instrumentation` version being used.
+  [#67](https://github.com/signalfx/splunk-otel-python/pull/67)
 
 ### Deprecated 
 

--- a/splunk_otel/options.py
+++ b/splunk_otel/options.py
@@ -19,6 +19,9 @@ from typing import Callable, Collection, Dict, List, Optional, Tuple, Union
 
 from opentelemetry.environment_variables import OTEL_TRACES_EXPORTER
 from opentelemetry.instrumentation.propagators import ResponsePropagator
+from opentelemetry.instrumentation.version import (
+    __version__ as auto_instrumentation_version,
+)
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_JAEGER_ENDPOINT,
     OTEL_SERVICE_NAME,
@@ -47,6 +50,7 @@ from splunk_otel.symbols import (
     _KNOWN_EXPORTER_PACKAGES,
     _NO_SERVICE_NAME_WARNING,
     _SERVICE_NAME_ATTR,
+    _SPLUNK_DISTRO_VERSION_ATTR,
     _TELEMETRY_VERSION_ATTR,
 )
 from splunk_otel.version import __version__
@@ -122,7 +126,12 @@ class Options:
         attributes = attributes or {}
         if service_name:
             attributes[_SERVICE_NAME_ATTR] = service_name
-        attributes.update({_TELEMETRY_VERSION_ATTR: __version__})
+        attributes.update(
+            {
+                _TELEMETRY_VERSION_ATTR: auto_instrumentation_version,
+                _SPLUNK_DISTRO_VERSION_ATTR: __version__,
+            }
+        )
         resource = Resource.create(attributes)
         if (
             resource.attributes.get(_SERVICE_NAME_ATTR, _DEFAULT_OTEL_SERVICE_NAME)

--- a/splunk_otel/symbols.py
+++ b/splunk_otel/symbols.py
@@ -23,6 +23,7 @@ _EXPORTER_JAEGER_THRIFT = "jaeger_thrift"
 _EXPORTER_JAEGER_SPLUNK = "jaeger-thrift-splunk"
 _DEFAULT_OTEL_SERVICE_NAME = "unknown_service"
 
+_SPLUNK_DISTRO_VERSION_ATTR = "splunk.distro.version"
 _SERVICE_NAME_ATTR = "service.name"
 _TELEMETRY_VERSION_ATTR = "telemetry.auto.version"
 _NO_SERVICE_NAME_WARNING = """service.name attribute is not set, your service is unnamed and will be difficult to identify.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -22,6 +22,7 @@ from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
 from splunk_otel.options import Options
 from splunk_otel.symbols import _DEFAULT_JAEGER_ENDPOINT, _DEFAULT_MAX_ATTR_LENGTH
+from splunk_otel.version import __version__
 
 # pylint: disable=protected-access
 
@@ -182,4 +183,12 @@ class TestOptions(TestCase):
                     "12345",
                 ),
             ),
+        )
+
+    def test_telemetry_attributes(self):
+        options = Options()
+        self.assertIsInstance(options.resource, Resource)
+        self.assertEqual(
+            options.resource.attributes["splunk.distro.version"],
+            __version__,
         )


### PR DESCRIPTION
# Description

We were using the version of splunk-otel-python as we had custom
instrumentation application but we've now only wrap
opentelemetry-instrumentation package so going forward we'll use that
version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [x] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added/updated
- [ ] Documentation has been updated
