### PR TITLE
Fix start_tracing argument name for span exporter factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed 
+
+- Renamed `exporters` argument `span_exporter_factories` for `start_tracing()` function.
+  [#71](https://github.com/signalfx/splunk-otel-python/pull/71)
+
 ## 0.13.0 (05-17-2021)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ start_tracing()
 # Also accepts optional config options:
 # start_tracing(
 #   service_name='my-python-service',
-#   exporter_factories=[OTLPSpanExporter]
+#   span_exporter_factories=[OTLPSpanExporter]
 #   access_token='',
 #   max_attr_length=1200,
 #   trace_response_header_enabled=True,

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -32,7 +32,7 @@ logger.setLevel(logging.INFO)
 
 def start_tracing(
     service_name: Optional[str] = None,
-    exporters: Optional[Collection[_SpanExporterFactory]] = None,
+    span_exporter_factories: Optional[Collection[_SpanExporterFactory]] = None,
     access_token: Optional[str] = None,
     max_attr_length: Optional[int] = None,
     resource_attributes: Optional[Dict[str, Union[str, bool, int, float]]] = None,
@@ -45,7 +45,7 @@ def start_tracing(
 
     options = Options(
         service_name,
-        exporters,
+        span_exporter_factories,
         access_token,
         max_attr_length,
         resource_attributes,


### PR DESCRIPTION
# Description

start_tracing was not using the correct attribute name for span exporters. This updates start_tracing function and documentation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested manually
- [ ] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [ ] Unit tests have been added/updated
- [x] Documentation has been updated
