### PR TITLE
Enable linter on splunk_otel/cmd directory

### DIFF
--- a/splunk_otel/cmd/bootstrap.py
+++ b/splunk_otel/cmd/bootstrap.py
@@ -13,16 +13,11 @@
 # limitations under the License.
 
 import argparse
-import pkgutil
-import subprocess
 import sys
 from logging import getLogger
-from typing import Any, Callable, Collection, Dict, Optional
 
-from opentelemetry.instrumentation.bootstrap import instrumentations
 from opentelemetry.instrumentation.bootstrap import run as otel_run
 
-from splunk_otel import symbols
 from splunk_otel.version import format_version_info
 
 logger = getLogger(__file__)

--- a/splunk_otel/cmd/trace.py
+++ b/splunk_otel/cmd/trace.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +15,8 @@
 
 import os
 import os.path
-import sys
 from argparse import REMAINDER, ArgumentParser
 from logging import getLogger
-from os import environ, execl, getcwd
-from shutil import which
-from typing import List, Union
 
 from opentelemetry.instrumentation.auto_instrumentation import run as otel_run
 


### PR DESCRIPTION
splunk_otel/cmd was being ignored by pylint because it did not have an __init__.py file. Added __init__.py to enable pylint on it.