### PR TITLE
Rename splk commands to splunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@
 - Log trace correlation is not enabled by default. Can be disabled by setting
   `OTEL_PYTHON_LOG_CORRELATION` env var to `false`.
   [#77](https://github.com/signalfx/splunk-otel-python/pull/77)
+- Added `splunk-py-trace` and `splunk-py-trace-bootstrap` commands as replacements for `splunk-py-trace` and `splunk-py-trace-bootstrap` respectively.
+  [#79](https://github.com/signalfx/splunk-otel-python/pull/79)
   
 ### Changed 
 
 - Renamed `options.Options` to `options._Options` to make it private.
   [#74](https://github.com/signalfx/splunk-otel-python/pull/74)
+
+### Deprecated
+
+- Deprecated `splunk-py-trace` and `splunk-py-trace-bootstrap` commands.
+  [#79](https://github.com/signalfx/splunk-otel-python/pull/79)
 
 ## 0.14.0 (05-20-2021)
 
@@ -66,12 +73,12 @@
 
 ### Added
 
-- Added support for `--access-token` and `--service-name` to `splk-py-trace` command.
+- Added support for `--access-token` and `--service-name` to `splunk-py-trace` command.
   [#34](https://github.com/signalfx/splunk-otel-python/pull/34)
 
 ### Changed
 
-- Updated splk-py-trace and splk-py-trace-bootstrap commands.
+- Updated splunk-py-trace and splunk-py-trace-bootstrap commands.
   Both commands now delegate to opentelemetry-instrument and opentelemetry-bootstrap commands.
   [#34](https://github.com/signalfx/splunk-otel-python/pull/34)
 - `start_tracing()` was moved from `splunk_otel.tracing` to `splunk_otel`.
@@ -82,7 +89,7 @@
 
 ### Removed
 
-- Removed support for `--exporters` CLI flag from `splk-py-trace-bootstrap` command.
+- Removed support for `--exporters` CLI flag from `splunk-py-trace-bootstrap` command.
   [#34](https://github.com/signalfx/splunk-otel-python/pull/34)
 
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -88,13 +88,13 @@ Follow these steps to deploy the Splunk Distribution for OpenTelemetry Python:
 3. Install instrumentations packages with the bootstrap
    command:
    ```
-   splk-py-trace-bootstrap
+   splunk-py-trace-bootstrap
    ```
    This command detects and installs instrumentation for every supported
    package it finds in your Python environment. To see which packages the
    command will install before running it, use this command:
    ```
-   splk-py-trace-bootstrap -a=requirements
+   splunk-py-trace-bootstrap -a=requirements
    ```
    You can integrate the bootstrap in your build/deployment process so
    instrumentation is configured every time you deploy the project. You can
@@ -117,8 +117,8 @@ Rename required environment variables:
 
 ### Step 3. Start you Python service
 
-Run your python service with the `splk-py-trace` command. If you run your service as `python main.py`, you
-can automatically instrument it with Splunk distribution of OpenTelemetry by running it as `splk-py-trace python main.py`.
+Run your python service with the `splunk-py-trace` command. If you run your service as `python main.py`, you
+can automatically instrument it with Splunk distribution of OpenTelemetry by running it as `splunk-py-trace python main.py`.
 
 ## Special cases
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ for Python.
 ## Getting Started
 
 To get started, install the `splunk-opentelemetry[all]` package, run the bootstrap
-script and wrap your run command with `splk-py-trace`.
+script and wrap your run command with `splunk-py-trace`.
 
 For example, if the runtime parameters were:
 
@@ -96,9 +96,9 @@ Then the runtime parameters should be updated to:
 
 ```
 $ pip install splunk-opentelemetry[all]
-$ splk-py-trace-bootstrap
+$ splunk-py-trace-bootstrap
 $ OTEL_SERVICE_NAME=my-python-app \
-    splk-py-trace python main.py --port=8000
+    splunk-py-trace python main.py --port=8000
 ```
 
 To see the Python instrumentation in action with sample applications, see our

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -70,7 +70,7 @@ More information about trace propagation can be found [here](configuring-propaga
 | OTEL_TRACE_ENABLED        |                       | `true`                    | Globally enables tracer creation and auto-instrumentation.                                                                                                                                                    |
 ## Instrument and configure with code
 
-If you cannot use `splk-py-trace` command, you can also add a couple of lines
+If you cannot use `splunk-py-trace` command, you can also add a couple of lines
 of code to your Python application to achieve the same result.
 
 ```python

--- a/docs/advanced-install.md
+++ b/docs/advanced-install.md
@@ -2,12 +2,12 @@
 
 ## Bootstrap: List requirements instead of installing them
 
-The `splk-py-trace-bootstrap` command can optionally print out the list of
+The `splunk-py-trace-bootstrap` command can optionally print out the list of
 packages it would install if you chose. In order to do so, pass
 `-a=requirements` CLI argument to it. For example,
 
 ```
-splk-py-trace-bootstrap -a requirements
+splunk-py-trace-bootstrap -a requirements
 ```
 
 Will output something like the following:

--- a/docs/instrumentation-special-cases.md
+++ b/docs/instrumentation-special-cases.md
@@ -2,7 +2,7 @@
 
 ## Celery
 
-Tracing Celery workers works out of the box when you use the `splk-py-trace`
+Tracing Celery workers works out of the box when you use the `splunk-py-trace`
 command to start your Python application. However, if you are instrumenting
 your celery workers with code, you'll need to make sure you setup tracing for
 each worker by using Celery's `celery.signals.worker_process_init` signal.
@@ -31,7 +31,7 @@ Django project as follows:
 
 ```
 export DJANGO_SETTINGS_MODULE=mydjangoproject.settings
-splk-py-trace ./manage.py runserver
+splunk-py-trace ./manage.py runserver
 ```
 
 ## Gunicorn

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 - Depending on the default python version on your system, you might want to use
   `pip3` and `python3` instead.
-- To be able to run `splk-py-trace` and `splk-py-trace-bootstrap`, the
+- To be able to run `splunk-py-trace` and `splunk-py-trace-bootstrap`, the
   directory pip installs scripts to will have to be on your system's PATH
   environment variable. Generally, this works out of the box when using virtual
   environments, installing packages system-wide or in container images. In some

--- a/examples/falcon/Makefile
+++ b/examples/falcon/Makefile
@@ -7,8 +7,8 @@ venv:
 .PHONY: install 
 install:
 	./venv/bin/pip install -r requirements.txt
-	./venv/bin/splk-py-trace-bootstrap
+	./venv/bin/splunk-py-trace-bootstrap
 
 .PHONY: run 
 run:
-	OTEL_EXPORTER_JAEGER_ENDPOINT='http://localhost:14268/api/traces' ./venv/bin/splk-py-trace python main.py	
+	OTEL_EXPORTER_JAEGER_ENDPOINT='http://localhost:14268/api/traces' ./venv/bin/splunk-py-trace python main.py	

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,11 @@ include = [
 ]
 
 [tool.poetry.scripts]
-splk-py-trace = 'splunk_otel.cmd.trace:run'
-splk-py-trace-bootstrap = 'splunk_otel.cmd.bootstrap:run'
+splunk-py-trace = 'splunk_otel.cmd.trace:run'
+splunk-py-trace-bootstrap = 'splunk_otel.cmd.bootstrap:run'
+# deprecated commands
+splk-py-trace = 'splunk_otel.cmd.trace:run_deprecated'
+splk-py-trace-bootstrap = 'splunk_otel.cmd.bootstrap:run_deprecated'
 
 [tool.poetry.plugins."opentelemetry_distro"]
 splunk_distro = "splunk_otel.distro:SplunkDistro"

--- a/splunk_otel/cmd/bootstrap.py
+++ b/splunk_otel/cmd/bootstrap.py
@@ -66,3 +66,13 @@ def run() -> None:
     if not args.action:
         sys.argv.append("--action=install")
     otel_run()
+
+
+def run_deprecated() -> None:
+    logger.warning(
+        (
+            "splk-py-trace-bootstrap is deprecated and will be removed in a future version. "
+            "Please use `splunk-py-trace-bootstrap` instead."
+        )
+    )
+    run()

--- a/splunk_otel/cmd/trace.py
+++ b/splunk_otel/cmd/trace.py
@@ -76,3 +76,13 @@ def run() -> None:
     except TypeError:
         logger.error("failed to execute program: %s", " ".join(args.command))
         raise
+
+
+def run_deprecated() -> None:
+    logger.warning(
+        (
+            "splk-py-trace is deprecated and will be removed in a future version. "
+            "Please use `splunk-py-trace` instead."
+        )
+    )
+    run()


### PR DESCRIPTION
# Description

Renamed `splk-*` commands to `splunk-*`. We did the same for env vars so no reason to have this inconsistency.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] Tested manually
- [ ] Added automated tests

# Checklist:

- [x] Changelogs have been updated
- [ ] Unit tests have been added/updated
- [x] Documentation has been updated
