### PR TITLE
Preparing release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,7 @@
 
 ## [Unreleased]
 
-## [1.0.0rc3] - 2021-06-08
-
-- Pin exact Otel deps until 1.0
-  [#88](https://github.com/signalfx/splunk-otel-python/pull/88)
-
-## [1.0.0-rc2] - 2021-06-03
-
-- Upgrade OpenTelemetry Python to 1.3.0 and 0.22b0
-  [#85](https://github.com/signalfx/splunk-otel-python/pull/85)
-
-## [1.0.0-rc1] - 2021-06-01
+## [0.16.0] - 2021-06-08
 
 ### Added
 
@@ -26,6 +16,12 @@
 
 - Renamed `options.Options` to `options._Options` to make it private.
   [#74](https://github.com/signalfx/splunk-otel-python/pull/74)
+- Pin exact Otel deps until 1.0
+  [#88](https://github.com/signalfx/splunk-otel-python/pull/88)
+- Upgrade OpenTelemetry Python to 1.3.0 and 0.22b0
+  [#85](https://github.com/signalfx/splunk-otel-python/pull/85)
+
+## [0.15.0] - 2021-06-08
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 </p>
 
 ---
-<span class="docs-version-header">The documentation below refers to the in development version of this package. Docs for the latest version ([v1.0.0rc3](https://github.com/signalfx/splunk-otel-python/releases/tag/v1.0.0rc3)) can be found [here](https://github.com/signalfx/splunk-otel-python/blob/v1.0.0rc3/README.md).</span>
+<span class="docs-version-header">The documentation below refers to the in development version of this package. Docs for the latest version ([v0.16.0](https://github.com/signalfx/splunk-otel-python/releases/tag/v0.16.0)) can be found [here](https://github.com/signalfx/splunk-otel-python/blob/v0.16.0/README.md).</span>
 ---
 
 # Splunk Distribution of OpenTelemetry Python
@@ -156,7 +156,7 @@ Documentation on how to manually instrument a Python application is available
 To extend the instrumentation with the OpenTelemetry Instrumentation for Python,
 you have to use a compatible API version.
 
-The Splunk Distribution of OpenTelemetry Python version <span class="splunk-version">1.0.0rc3</span> is compatible
+The Splunk Distribution of OpenTelemetry Python version <span class="splunk-version">0.16.0</span> is compatible
 with:
 
 * OpenTelemetry API version <span class="otel-api-version">1.3.0</span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splunk-opentelemetry"
-version = "1.0.0rc3"
+version = "0.16.0"
 description = "The Splunk distribution of OpenTelemetry Python Instrumentation provides a Python agent that automatically instruments your Python application to capture and report distributed traces to SignalFx APM."
 authors = ["Splunk <splunk-oss@splunk.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This back ports 1.0.0rc3 into 0.16.0 as using rc is a bit problematic for some users. We'll continue with 0.x series going forward until we are ready to release 1.0.