### PR TITLE
Replace keepachangelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ## 0.17.0 - 2021-08-29
+
 ### General
 
 - Upgraded Otel dependencies to 1.5.0 and 0.24.0b0

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,7 +231,7 @@ python-versions = "*"
 
 [[package]]
 name = "docker"
-version = "5.0.0"
+version = "5.0.1"
 description = "A Python library for the Docker Engine API."
 category = "dev"
 optional = false
@@ -429,7 +429,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 name = "keepachangelog"
 version = "1.0.0"
 description = "Manipulate keep a changelog files."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -984,7 +984,7 @@ otlp = ["opentelemetry-exporter-otlp-proto-grpc"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "787d68cdcb27f10cb8133cd0c12e797a097b258f0824baf1d75ee9cfa6a93df7"
+content-hash = "13fb940baeb3bbe1fd30686c1e372d3223fc5c599ff24c7c2f225e99382b1742"
 
 [metadata.files]
 aiocontextvars = [
@@ -1179,8 +1179,8 @@ distro = [
     {file = "distro-1.6.0.tar.gz", hash = "sha256:83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424"},
 ]
 docker = [
-    {file = "docker-5.0.0-py2.py3-none-any.whl", hash = "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"},
-    {file = "docker-5.0.0.tar.gz", hash = "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5"},
+    {file = "docker-5.0.1-py2.py3-none-any.whl", hash = "sha256:b88eef725b33c0ed59c67506631bbb09b480b7ca5a739bbbb948b446443fe914"},
+    {file = "docker-5.0.1.tar.gz", hash = "sha256:5aafaec0d2a1de0e32010b43b5eac9f6f851c9db99a46ad32b8e44eeeb55616d"},
 ]
 docker-compose = [
     {file = "docker-compose-1.29.2.tar.gz", hash = "sha256:4c8cd9d21d237412793d18bd33110049ee9af8dab3fe2c213bbd0733959b09b7"},
@@ -1441,13 +1441,9 @@ protobuf = [
     {file = "protobuf-3.17.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2ae692bb6d1992afb6b74348e7bb648a75bb0d3565a3f5eea5bec8f62bd06d87"},
     {file = "protobuf-3.17.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99938f2a2d7ca6563c0ade0c5ca8982264c484fdecf418bd68e880a7ab5730b1"},
     {file = "protobuf-3.17.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6902a1e4b7a319ec611a7345ff81b6b004b36b0d2196ce7a748b3493da3d226d"},
-    {file = "protobuf-3.17.3-cp38-cp38-win32.whl", hash = "sha256:59e5cf6b737c3a376932fbfb869043415f7c16a0cf176ab30a5bbc419cd709c1"},
-    {file = "protobuf-3.17.3-cp38-cp38-win_amd64.whl", hash = "sha256:ebcb546f10069b56dc2e3da35e003a02076aaa377caf8530fe9789570984a8d2"},
     {file = "protobuf-3.17.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4ffbd23640bb7403574f7aff8368e2aeb2ec9a5c6306580be48ac59a6bac8bde"},
     {file = "protobuf-3.17.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:26010f693b675ff5a1d0e1bdb17689b8b716a18709113288fead438703d45539"},
     {file = "protobuf-3.17.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e76d9686e088fece2450dbc7ee905f9be904e427341d289acbe9ad00b78ebd47"},
-    {file = "protobuf-3.17.3-cp39-cp39-win32.whl", hash = "sha256:a38bac25f51c93e4be4092c88b2568b9f407c27217d3dd23c7a57fa522a17554"},
-    {file = "protobuf-3.17.3-cp39-cp39-win_amd64.whl", hash = "sha256:85d6303e4adade2827e43c2b54114d9a6ea547b671cb63fafd5011dc47d0e13d"},
     {file = "protobuf-3.17.3-py2.py3-none-any.whl", hash = "sha256:2bfb815216a9cd9faec52b16fd2bfa68437a44b67c56bee59bc3926522ecb04e"},
     {file = "protobuf-3.17.3.tar.gz", hash = "sha256:72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -429,7 +429,7 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 name = "keepachangelog"
 version = "1.0.0"
 description = "Manipulate keep a changelog files."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -984,7 +984,7 @@ otlp = ["opentelemetry-exporter-otlp-proto-grpc"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "13fb940baeb3bbe1fd30686c1e372d3223fc5c599ff24c7c2f225e99382b1742"
+content-hash = "787d68cdcb27f10cb8133cd0c12e797a097b258f0824baf1d75ee9cfa6a93df7"
 
 [metadata.files]
 aiocontextvars = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ opentelemetry-semantic-conventions = "0.24b0"
 opentelemetry-propagator-b3 = {version = "1.5.0", optional = true} 
 opentelemetry-exporter-jaeger-thrift = {version = "1.5.0", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.5.0", optional = true}
+keepachangelog = "^1.0.0"
 
 [tool.poetry.extras]
 all = ["opentelemetry-propagator-b3", "opentelemetry-exporter-otlp-proto-grpc", "opentelemetry-exporter-jaeger-thrift"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ opentelemetry-semantic-conventions = "0.24b0"
 opentelemetry-propagator-b3 = {version = "1.5.0", optional = true} 
 opentelemetry-exporter-jaeger-thrift = {version = "1.5.0", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.5.0", optional = true}
-keepachangelog = "^1.0.0"
 
 [tool.poetry.extras]
 all = ["opentelemetry-propagator-b3", "opentelemetry-exporter-otlp-proto-grpc", "opentelemetry-exporter-jaeger-thrift"]

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import re
+from datetime import datetime
 from os import path
 
 import click
-import keepachangelog
 from splunk_packaging import bump_version, changelog_path, get_versions, root_path
 
 readme_path = path.join(root_path, "README.md")
@@ -66,6 +66,16 @@ def update_docs(versions):
         readme.write(markdown)
 
 
+def update_changelog(file_path, version):
+    release_title = "## {0} - {1}".format(version, datetime.today().strftime("%Y-%m-%d"))
+    with open(file_path, "r+", encoding="utf-8") as file:
+        modified = file.read().replace(
+            "## Unreleased", "## Unreleased\n\n{0}".format(release_title), 1
+        )
+        file.seek(0)
+        file.write(modified)
+
+
 @click.command()
 @click.option(
     "--version",
@@ -75,7 +85,7 @@ def main(version):
     bump_version(version)
     versions = get_versions()
     update_docs(versions)
-    keepachangelog.release(changelog_path, versions.distro)
+    update_changelog(changelog_path, versions.distro)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We switched to Splunk GDI format so keepachangelog does not work anymore. Replaced it with a simple function.