### PR TITLE
Edit README and docs files to point to official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <p align="center">
   <strong>
-    <a href="#getting-started">Getting Started</a>
+    <a href="https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/get-started.html">Get Started</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-    <a href="CONTRIBUTING.md">Getting Involved</a>
+    <a href="CONTRIBUTING.md">Get Involved</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-    <a href="MIGRATING.md">Migrating from SignalFx Python Tracing</a>
+    <a href="https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/troubleshooting/migrate-signalfx-python-agent-to-otel.html">Migrating from SignalFx Python Tracing</a>
   </strong>
 </p>
 
@@ -37,50 +37,46 @@
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md">Supported Libraries</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-    <a href="docs/troubleshooting.md">Troubleshooting</a>
+    <a href="https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/troubleshooting/common-python-troubleshooting.html">Troubleshooting</a>
   </strong>
 </p>
-
----
-<span class="docs-version-header">The documentation below refers to the in development version of this package. Docs for the latest version ([v0.17.0](https://github.com/signalfx/splunk-otel-python/releases/tag/v0.17.0)) can be found [here](https://github.com/signalfx/splunk-otel-python/blob/v0.17.0/README.md).</span>
----
 
 # Splunk Distribution of OpenTelemetry Python
 
 The Splunk distribution of [OpenTelemetry
 Python](https://github.com/open-telemetry/opentelemetry-python) provides
-multiple installable packages that automatically instruments your Python
+multiple installable packages that automatically instrument your Python
 application to capture and report distributed traces to Splunk APM.
 Instrumentation works by patching supported libraries at runtime with an
 OpenTelemetry-compatible tracer to capture and export trace spans.
 
-This Splunk distribution comes with the following defaults:
+This distribution comes with the following defaults:
 
 - [W3C tracecontext](https://www.w3.org/TR/trace-context/) and [W3C
   baggage](https://www.w3.org/TR/baggage/) context propagation;
   [B3](https://github.com/openzipkin/b3-propagation) can also be
-  [configured](docs/advanced-config.md#trace-propagation-configuration).
+  [configured](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.html).
 - [OTLP gRPC
   exporter](https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html)
   configured to send spans to a locally running [Splunk OpenTelemetry
   Connector](https://github.com/signalfx/splunk-otel-collector)
   (`http://localhost:4317`).
-- Unlimited default limits for [configuration options](docs/advanced-config.md#trace-configuration) to
+- Unlimited default limits for [configuration options](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.html) to
   support full-fidelity traces.
 
 If you're currently using the SignalFx Tracing Library for Python and want to
 migrate to the Splunk Distribution of OpenTelemetry Python, see [Migrate from
-the SignalFx Tracing Library for Python](MIGRATING.md).
+the SignalFx Tracing Library for Python](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/troubleshooting/migrate-signalfx-python-agent-to-otel.html#nav-Migrate-from-SignalFX-Python-agent).
 
-> :construction: This project is currently in **BETA**. It is **officially supported** by Splunk. However, breaking changes **MAY** be introduced.
+---
+This README refers to the in development version of this package. Docs for the latest version ([v0.17.0](https://github.com/signalfx/splunk-otel-python/releases/tag/v0.17.0)) can be found [here](https://github.com/signalfx/splunk-otel-python/blob/v0.17.0/README.md).
+---
 
 ## Requirements
 
 This Splunk Distribution of OpenTelemetry requires Python 3.6 or later.
-If you're still using Python 2, continue using the SignalFx Tracing Library
-for Python.
 
-## Getting Started
+## Get started
 
 To get started, install the `splunk-opentelemetry[all]` package, run the bootstrap
 script and wrap your run command with `splunk-py-trace`.
@@ -103,11 +99,11 @@ $ OTEL_SERVICE_NAME=my-python-app \
 To see the Python instrumentation in action with sample applications, see our
 [examples](https://github.com/signalfx/tracing-examples/tree/main/opentelemetry-tracing/opentelemetry-python-tracing).
 
-### Basic Configuration
+### Basic configuration
 
 The service name resource attribute is the only configuration option
 that needs to be specified. You can set it by adding a `service.name`
-attribute as shown in the [example above](#getting-started).
+attribute as shown in the [example above](#get-started).
 
 A few other configuration options that may need to be changed or set are:
 
@@ -140,13 +136,13 @@ The `OTEL_RESOURCE_ATTRIBUTES` syntax is described in detail in the
 
 ### Supported Python Versions
 
-The instrumentation works with Python verion 3.6 and higher. Supported
+The instrumentation works with Python verion 3.6 or higher. Supported
 libraries are listed
 [here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation).
 
 ## Advanced Configuration
 
-For the majority of users, the [Getting Started](#getting-started) section is
+For the majority of users, the [Getting Started](#get-started) section is
 all you need. Advanced configuration documentation can be found
 [here](docs/advanced-config.md). In addition, special cases for instrumentation
 are documented [here](docs/instrumentation-special-cases.md).
@@ -154,7 +150,7 @@ are documented [here](docs/instrumentation-special-cases.md).
 ## Manually instrument an application
 
 Documentation on how to manually instrument a Python application is available
-[here](https://opentelemetry-python.readthedocs.io/en/stable/getting-started.html).
+[here](https://opentelemetry-python.readthedocs.io/en/stable/get-started.html).
 
 To extend the instrumentation with the OpenTelemetry Instrumentation for Python,
 you have to use a compatible API version.
@@ -169,9 +165,7 @@ with:
 ## Correlating traces with logs
 
 The Splunk Distribution of OpenTelemetry Python provides a way
-to correlate traces with logs. It is enabled automatically as part of the
-[logging
-instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html).
+to correlate traces with logs. See [Connect Python trace data with logs](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/instrumentation/connect-traces-logs.html).
 
 # License and versioning
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ are documented [here](docs/instrumentation-special-cases.md).
 ## Manually instrument an application
 
 Documentation on how to manually instrument a Python application is available
-[here](https://opentelemetry-python.readthedocs.io/en/stable/get-started.html).
+[here](https://opentelemetry-python.readthedocs.io/en/stable/getting-started.html).
 
 To extend the instrumentation with the OpenTelemetry Instrumentation for Python,
 you have to use a compatible API version.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,34 +5,35 @@ This document explains the steps required to publish a new release of splunk-ope
 
 Release process:
 
-1. [Checkout a release branch](#step-1)
-2. [Update version number and changelog](#step-2)
-3. [Submit PR for review and merge to main](#step-3)
-4. [Create a new Github Release](#step-4)
-5. [Create and push tag](#step-5)
-6. [Verify CircleCI and PYPI](#step-6)
+1. [Checkout a release branch](#1-checkout-a-release-branch)
+2. [Update version number and changelog](#2-update-the-version-number)
+3. [Submit PR for review and merge to main](#3-submit-changes-for-review)
+4. [Create a new Github Release](#4-create-a-draft-github-release)
+5. [Create and push tag](#5-create-and-publish-a-version-git-tag)
+6. [Verify CircleCI and PYPI](#6-verify-circleci-job-and-pypi-package)
+7. [Publish the draft GitHub Release](#7-publish-the-draft-github-release)
 
 
-## 1. Checkout a release branch <a href="step-1"></a>
+## 1. Checkout a release branch
 
 Checkout a new branch from main with name equal to `release/v<VERSION_NUMBER>`.
 So if you intent to release `1.2.0`, create a branch named `release/v1.2.0`
 
-## 2. Update version number <a href="step-2"></a>
+## 2. Update the version number
 
 Update version in `pyproject.toml`.
 
 In CHANGELOG.md, rename `Unreleased` header with the new version and today's date.
 Add a new empty `Unreleased` section at top.
 
-## 3. Submit changes for review <a href="step-3"></a>
+## 3. Submit changes for review
 
 Commit the changes and submit them for review.
 The commit title should be `Release v<VERSION_NUMBER>` and the description should be all the changes,
 additions and deletions this versions will ship. This can be copied as is from the CHANGELOG file.
 Merge the PR back to main once it is approved. 
 
-## 4.Create a draft Github Release <a href="step-4"></a>
+## 4. Create a draft GitHub Release
 
 Go to the (project on Github)[https://github.com/signalfx/splunk-otel-js] and create a new release.
 On top of the release notes mention the version of OpenTelemetry API and other packages this
@@ -44,8 +45,7 @@ Release name should be exact version number without the prefix `v` we use elsewh
 
 Save the release as a draft.
 
-
-## 5. Create and publish version git tag <a href="step-5"></a>
+## 5. Create and publish a version git tag
 
 Switch to `main` branch and pull the latest changes. Make sure your git head is on the release commit.
 Switch to the commit if it is not. 
@@ -57,7 +57,7 @@ git tag v1.2.0
 git push origin v1.2.0
 ```
 
-## 6. Verify CircleCI job and PYPI package <a href="step-6"></a>
+## 6. Verify CircleCI job and PYPI package
 
 Go to (the CircleCI project)[https://app.circleci.com/pipelines/github/signalfx/splunk-otel-python] and verify the build for your new version was successful.
 
@@ -65,6 +65,6 @@ Go to (https://pypi.org/project/splunk-opentelemetry/)[https://pypi.org/project/
 
 Navigate to examples/falcon, upgrade `splunk-opentelemetry` package to the new version and verify it is working as expected. If you're feeling like doing some more work, commit the changes to the example falcon app and submit a PR.
 
-## 7. Publish the draft Github Release
+## 7. Publish the draft GitHub Release
 
-Pull up the draft Github Release you created earlier in step 4 and publish it. 
+Pull up the draft GitHub Release you created earlier in step 4 and publish it. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+The official documentation for this distribution can be found here:
+
+https://docs.splunk.com/Observability/gdi/get-data-in/application/python/get-started.html

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Configure the Python agent](https://docs.splunk.com/Observability/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.html).
+
 # Advanced Configuration
 
 ## Splunk distribution configuration

--- a/docs/advanced-install.md
+++ b/docs/advanced-install.md
@@ -1,3 +1,4 @@
+> The official Splunk documentation for this page is [Instrument a Python application automatically](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/instrumentation/instrument-python-application.html).
 # Advanced Installation
 
 ## Bootstrap: List requirements instead of installing them

--- a/docs/configuring-propagators.md
+++ b/docs/configuring-propagators.md
@@ -1,3 +1,4 @@
+> The official Splunk documentation for this page is [Configure the Python agent](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.html#trace-propagation-configuration-python).
 # Configuring Propagators
 
 This package uses W3C trace context and W3C baggage propagators by default. You can override

--- a/docs/exporting-data.md
+++ b/docs/exporting-data.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Configure the Python agent](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.html#trace-exporters-settings-python).
+
 # Exporting telemetry data
 
 This package can export spans in the OTLP format over gRPRC or Jaeger Thrift

--- a/docs/instrumentation-special-cases.md
+++ b/docs/instrumentation-special-cases.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Additional instructions for Python frameworks](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/instrumentation/instrument-python-frameworks.html).
+
 # Instrumentation Special Cases
 
 ## Celery

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,5 @@
+> The official Splunk documentation for this page is [Troubleshoot Python instrumentation](https://docs.signalfx.com/en/observability/gdi/get-data-in/application/python/troubleshooting/common-python-troubleshooting.html).
+
 # Troubleshooting
 
 - Depending on the default python version on your system, you might want to use


### PR DESCRIPTION
The official Python OTel docs are now on our docs site:

https://docs.splunk.com/Observability/gdi/get-data-in/application/python/get-started.html

This PR updates the README to point to the official docs when appropriate, as per our new content strategy. Docs will still remain here though, to facilitate knowledge transfer.

Similar PR: https://github.com/signalfx/splunk-otel-java/pull/373