### PR TITLE
Support OTEL_TRACE_ENABLED in ditro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add support for OTEL_TRACE_ENABLED to splunk-py-trace command.
+  [#199](https://github.com/signalfx/splunk-otel-python/pull/199)
+
 ## 1.3.0 - 2021-12-20
 
 ### General


### PR DESCRIPTION

# Description

OTEL_TRACE_ENABLED was only supported when configuring the SDK with
code. It was ignored by the distro which is used by
auto-instrumentation. This change adds support for it to the distro as well.
