### PR TITLE
Remove python 3.6 test from gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,12 +41,6 @@ lint:
     PY_VERSION: "3.9"
     TOX_ENV: lint
 
-test-py36:
-  extends: .tox
-  variables:
-    PY_VERSION: "3.6"
-    TOX_ENV: py36-test
-
 test-py37:
   extends: .tox
   variables:


### PR DESCRIPTION
# Description

As part of dropping python 3.6 support, I missed the `.gitlab-ci.yml` file and, unsurprisingly, the gitlab build broke.
