### PR TITLE
Fix docs around releasing

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,24 +35,4 @@ without the need to install the package again.
 
 ## Releasing
 
-Assuming the latest version is 0.14.0 and you want to releaase 0.15.0,
-
-1. Run `make prepare-release VERSION=0.15.0` 
-   This will bump the version where neccesary, update the changelog and commit
-   all the changes to a new branch with name `release/v0.15.0`.
-2. Submit a GitHub PR for the new branch and merge it once it is approved.
-3. Switch to the main branch and pull the newly merged changes. Make sure you have the same commit
-   checked out that was auto-generated in step 1.
-4. Tag the commit with the version number
-   ```shell
-   git tag -s v0.15.0
-   ```
-5. Push the new tag to bot GitHub and GitLab
-   ```shell
-   git push github v0.15.0
-   git push gitlab v0.15.0
-   ```
-   This will kickoff a Gitlab release job which will publish packages to pypi.org
-   and create a new GitHub release.
-6. You should review the GitHub release and add
-   additional information to it if required.
+See RELEASING.md.


### PR DESCRIPTION
# Description

While attempting to release a new version, I followed some out-of-date documentation.  This is now patched by pointing to the correct procedure in another document.