### PR TITLE
Preparing release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.9.1 - 2023-02-14
+
 ## 1.9.0 - 2023-02-13
 
 - Upgraded Otel dependencies to 1.15.0 and 0.36b0.  This removes support for Python 3.6.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Documentation on how to manually instrument a Python application is available
 To extend the instrumentation with the OpenTelemetry Instrumentation for Python,
 you have to use a compatible API version.
 
-The Splunk Distribution of OpenTelemetry Python version <span class="splunk-version">1.9.0</span> is compatible
+The Splunk Distribution of OpenTelemetry Python version <span class="splunk-version">1.9.1</span> is compatible
 with:
 
 * OpenTelemetry API version <span class="otel-api-version">1.15.0</span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splunk-opentelemetry"
-version = "1.9.0"
+version = "1.9.1"
 description = "The Splunk distribution of OpenTelemetry Python Instrumentation provides a Python agent that automatically instruments your Python application to capture and report distributed traces to SignalFx APM."
 authors = ["Splunk <splunk-oss@splunk.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# Description

1.9.1 has no features or changes from 1.9.0. This is purely to push through a failure in the release process.

Note that 1.9.x drops supports for Python 3.6.