### PR TITLE
chore: remove lint from gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,12 +40,6 @@ build:
       - dist/
     when: always
 
-lint:
-  extends: .tox
-  variables:
-    PY_VERSION: "3.9"
-    TOX_ENV: lint
-
 test-py37:
   extends: .tox
   variables:


### PR DESCRIPTION
For some reason GitLab's lint result is different from GitHub's.

This can cause releases to be messed up, requiring too much manual intervention. GitHub's lint job should be enough.


I think the whole GitLab pipeline needs to be rethought a bit, even the tests should not run there :thinking: 