### PR TITLE
Fix github release script backoff exception type

### DIFF
--- a/scripts/create_gh_release.py
+++ b/scripts/create_gh_release.py
@@ -14,7 +14,6 @@
 
 from os import path
 from time import sleep
-from urllib3.exceptions import HTTPError
 
 import backoff
 import click
@@ -58,7 +57,7 @@ Run with --dry-run=false to create the following release
     default=True,
     help="Print out the release details instead of actually creating one",
 )
-@backoff.on_exception(backoff.expo, HTTPError, max_time=60)
+@backoff.on_exception(backoff.expo, (requests.exceptions.HTTPError, urllib3.exceptions.HTTPError), max_time=60)
 def main(dry_run):
     versions = get_versions()
 

--- a/scripts/create_gh_release.py
+++ b/scripts/create_gh_release.py
@@ -18,6 +18,8 @@ from time import sleep
 import backoff
 import click
 import keepachangelog
+import requests
+import urllib3
 from github_release import gh_release_create
 from splunk_packaging import changelog_path, get_versions, root_path
 


### PR DESCRIPTION
The github release script broke recently and it appears that either the exception type on a 404 changed or it can be multiple types depending on path, so I broadened the `@backoff` decoration to accommodate that.