### PR TITLE
Add 'Skip Changelog' label to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "Skip Changelog"
     allowed_updates:
       - match:
           update_type: "security"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "daily"
     labels:
       - "Skip Changelog"
+      - "dependencies"
     allowed_updates:
       - match:
           update_type: "security"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,3 @@ updates:
     labels:
       - "Skip Changelog"
       - "dependencies"
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
Dependabot PRs are a pain to merge since you have to manually mark them as "Skip Changelog".  This fixes that.  Note that for "major" changes (e.g., updating opentelemetry sdk versions) there is no reason an approver/maintainer could not manually remove that label.

Also, the dependabot config also contained an outdated `allowed_updates` section.  This was apparently ignored by the bot runs anyway, but needed to be fixed before the CI would allow further modifications to this file.