### PR TITLE
Don't hardcode assumption of grpc module during init, to make lambdas easier

### DIFF
--- a/splunk_otel/metrics.py
+++ b/splunk_otel/metrics.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 def start_metrics() -> MeterProvider:
+    # pylint disable=import-outside-toplevel
     from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 
     enabled = os.environ.get("OTEL_METRICS_ENABLED", True)
@@ -42,6 +43,7 @@ def start_metrics() -> MeterProvider:
 
 
 def _configure_metrics() -> MeterProvider:
+    # pylint disable=import-outside-toplevel
     from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
         OTLPMetricExporter,
     )

--- a/splunk_otel/metrics.py
+++ b/splunk_otel/metrics.py
@@ -15,11 +15,7 @@
 import logging
 import os
 
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
-from opentelemetry.metrics import set_meter_provider
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
 from splunk_otel.util import _is_truthy
 
@@ -27,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 def start_metrics() -> MeterProvider:
+    from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+
     enabled = os.environ.get("OTEL_METRICS_ENABLED", True)
     if not _is_truthy(enabled):
         logger.info("metering has been disabled with OTEL_METRICS_ENABLED=%s", enabled)
@@ -44,6 +42,12 @@ def start_metrics() -> MeterProvider:
 
 
 def _configure_metrics() -> MeterProvider:
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+        OTLPMetricExporter,
+    )
+    from opentelemetry.metrics import set_meter_provider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
     metrics_exporter = OTLPMetricExporter()
     meter_provider = MeterProvider([PeriodicExportingMetricReader(metrics_exporter)])
     set_meter_provider(meter_provider)

--- a/splunk_otel/metrics.py
+++ b/splunk_otel/metrics.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 def start_metrics() -> MeterProvider:
-    # pylint disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 
     enabled = os.environ.get("OTEL_METRICS_ENABLED", True)
@@ -43,7 +43,7 @@ def start_metrics() -> MeterProvider:
 
 
 def _configure_metrics() -> MeterProvider:
-    # pylint disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
         OTLPMetricExporter,
     )


### PR DESCRIPTION
Lambdas have an unusual use case of wanting to use http/protobuf instead of grpc.  Even when not calling `start_metrics`, during init/process start the parsing of the import statements causes an error using `splunk-otel-python > 1.13` because of the hardcoded import of the grpc-based exporter.  Moving the imports inside appropriate the function calls should address that, but I think more work will come later to clean up metric initialization/export/environment variable handling besides this. 



