### PR TITLE
fix: profiling: properly format trace context strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Upgraded Otel dependencies to 1.21.0 / 0.42b0
+- Fix trace and span id formatting for profiling
+  [#372](https://github.com/signalfx/splunk-otel-python/pull/372)
 
 ## 1.15.0 - 2023-11-15
 

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -226,12 +226,12 @@ class Profiler:
 
                 trace_id_label = profile_pb2.Label()
                 trace_id_label.key = trace_id_key
-                trace_id_label.str = str_table.index(f"{trace_id:#016x}")
+                trace_id_label.str = str_table.index(f"{trace_id:016x}")
                 labels.append(trace_id_label)
 
                 span_id_label = profile_pb2.Label()
                 span_id_label.key = span_id_key
-                span_id_label.str = str_table.index(f"{span_id:#08x}")
+                span_id_label.str = str_table.index(f"{span_id:08x}")
                 labels.append(span_id_label)
 
             sample = profile_pb2.Sample()

--- a/tests/unit/test_profiling.py
+++ b/tests/unit/test_profiling.py
@@ -164,10 +164,12 @@ class TestProfiling(unittest.TestCase):
                 self.assertGreater(len(file_name), 0)
 
                 if function_name == "do_work":
-                    span_id = int(strings[find_label(sample, "span_id", strings).str], 16)
-                    trace_id = int(
-                        strings[find_label(sample, "trace_id", strings).str], 16
-                    )
+                    span_id_str = strings[find_label(sample, "span_id", strings).str]
+                    trace_id_str = strings[find_label(sample, "trace_id", strings).str]
+                    self.assertFalse(span_id_str.startswith("0x"))
+                    self.assertFalse(trace_id_str.startswith("0x"))
+                    span_id = int(span_id_str, 16)
+                    trace_id = int(trace_id_str, 16)
                     self.assertEqual(span_id, self.span_id)
                     self.assertEqual(trace_id, self.trace_id)
                     return True


### PR DESCRIPTION
trace and span ids were formatted with `0x` prefix and this went unnoticed in the tests.

