### PR TITLE
Explicitly shut down meter provider in a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ The Splunk distribution of OpenTelemetry Python Instrumentation is a
 distribution of [OpenTelemetry Python](https://github.com/open-telemetry/opentelemetry-python).
 It is licensed under the terms of the Apache Software License version 2.0.
 See [the license file](./LICENSE) for more details.
+

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -40,6 +40,7 @@ class TestMetrics(TestCase):
     def test_metrics_enabled(self):
         meter_provider = start_metrics()
         self.assertIsInstance(meter_provider, MeterProvider)
+        meter_provider.shutdown(1)
 
     def test_configure_metrics(self):
         meter_provider = _configure_metrics()


### PR DESCRIPTION
Otherwise the test hangs for ~30s.