### PR TITLE
Explicitly shut down meter provider in a test

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -40,6 +40,7 @@ class TestMetrics(TestCase):
     def test_metrics_enabled(self):
         meter_provider = start_metrics()
         self.assertIsInstance(meter_provider, MeterProvider)
+        meter_provider.shutdown(1)
 
     def test_configure_metrics(self):
         meter_provider = _configure_metrics()


### PR DESCRIPTION
Otherwise the test hangs for ~30s