### PR TITLE
Reorg Options' methods

### DIFF
--- a/splunk_otel/options.py
+++ b/splunk_otel/options.py
@@ -78,159 +78,159 @@ class _Options:
         resource_attributes: Optional[Dict[str, Union[str, bool, int, float]]] = None,
         trace_response_header_enabled: Optional[bool] = None,
     ):
-        self._set_default_env()
-        self.access_token = self._get_access_token(access_token)
-        self.response_propagator = self._get_trace_response_header_enabled(
+        _set_default_env()
+        self.access_token = _get_access_token(access_token)
+        self.response_propagator = _get_trace_response_header_enabled(
             trace_response_header_enabled
         )
-        self.resource = self._get_resource(service_name, resource_attributes)
-        self.span_exporter_factories = self._get_span_exporter_factories(
+        self.resource = _get_resource(service_name, resource_attributes)
+        self.span_exporter_factories = _get_span_exporter_factories(
             span_exporter_factories
         )
 
-    @staticmethod
-    def _get_access_token(access_token: Optional[str]) -> Optional[str]:
-        if not access_token:
-            access_token = environ.get(_SPLUNK_ACCESS_TOKEN)
-        return access_token or None
 
-    @staticmethod
-    def _get_trace_response_header_enabled(
-        enabled: Optional[bool],
-    ) -> Optional[ResponsePropagator]:
-        if enabled is None:
-            enabled = _Options._is_truthy(
-                environ.get(_SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true")
-            )
-        if enabled:
-            return _ServerTimingResponsePropagator()
-        return None
+def _get_access_token(access_token: Optional[str]) -> Optional[str]:
+    if not access_token:
+        access_token = environ.get(_SPLUNK_ACCESS_TOKEN)
+    return access_token or None
 
-    @staticmethod
-    def _get_resource(
-        service_name: Optional[str],
-        attributes: Optional[Dict[str, Union[str, bool, int, float]]],
-    ) -> Resource:
-        attributes = attributes or {}
-        if service_name:
-            attributes[_SERVICE_NAME_ATTR] = service_name
-        attributes.update(
-            {
-                _TELEMETRY_VERSION_ATTR: auto_instrumentation_version,
-                _SPLUNK_DISTRO_VERSION_ATTR: __version__,
-            }
+
+def _get_trace_response_header_enabled(
+    enabled: Optional[bool],
+) -> Optional[ResponsePropagator]:
+    if enabled is None:
+        enabled = _is_truthy(
+            environ.get(_SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true")
         )
-        resource = Resource.create(attributes)
-        if (
-            resource.attributes.get(_SERVICE_NAME_ATTR, _DEFAULT_OTEL_SERVICE_NAME)
-            == _DEFAULT_OTEL_SERVICE_NAME
-        ):
-            logger.warning(_NO_SERVICE_NAME_WARNING)
-            resource = resource.merge(
-                Resource({_SERVICE_NAME_ATTR: _DEFAULT_SERVICE_NAME})
-            )
-        return resource
+    if enabled:
+        return _ServerTimingResponsePropagator()
+    return None
 
-    @staticmethod
-    def _get_span_exporter_factories(
-        factories: Optional[Collection[_SpanExporterFactory]],
-    ) -> Collection[_SpanExporterFactory]:
-        if factories:
-            return factories
 
-        exporter_names = _Options._get_span_exporter_names_from_env()
-        return _Options._import_span_exporter_factories(exporter_names)
-
-    @classmethod
-    def _is_truthy(cls, value: Optional[str]) -> bool:
-        if not value:
-            return False
-
-        return value.strip().lower() not in (
-            "false",
-            "no",
-            "f",
-            "0",
-        )
-
-    @staticmethod
-    def _set_default_env() -> None:
-        defaults = {
-            OTEL_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
-            OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
-            OTEL_SPAN_EVENT_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
-            OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
-            OTEL_LINK_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
-            OTEL_SPAN_LINK_COUNT_LIMIT: str(_DEFAULT_SPAN_LINK_COUNT_LIMIT),
-            OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT: str(_DEFAULT_MAX_ATTR_LENGTH),
+def _get_resource(
+    service_name: Optional[str],
+    attributes: Optional[Dict[str, Union[str, bool, int, float]]],
+) -> Resource:
+    attributes = attributes or {}
+    if service_name:
+        attributes[_SERVICE_NAME_ATTR] = service_name
+    attributes.update(
+        {
+            _TELEMETRY_VERSION_ATTR: auto_instrumentation_version,
+            _SPLUNK_DISTRO_VERSION_ATTR: __version__,
         }
-
-        for key, value in defaults.items():
-            if key not in environ:
-                environ[key] = value
-
-    @classmethod
-    def _get_span_exporter_names_from_env(cls) -> Collection[Tuple[str, str]]:
-        exporters_env = (
-            environ.get(OTEL_TRACES_EXPORTER, "").strip() or _DEFAULT_EXPORTERS
+    )
+    resource = Resource.create(attributes)
+    if (
+        resource.attributes.get(_SERVICE_NAME_ATTR, _DEFAULT_OTEL_SERVICE_NAME)
+        == _DEFAULT_OTEL_SERVICE_NAME
+    ):
+        logger.warning(_NO_SERVICE_NAME_WARNING)
+        resource = resource.merge(
+            Resource({_SERVICE_NAME_ATTR: _DEFAULT_SERVICE_NAME})
         )
+    return resource
 
-        exporters: List[Tuple[str, str]] = []
-        if not cls._is_truthy(exporters_env):
-            return exporters
 
-        # exporters are known by different names internally by Python Otel SDK.
-        # Here we create a mapping of user provided names to internal names so
-        # that we can provide helpful error messages later.
-        for name in exporters_env.split(","):
-            if name == _EXPORTER_OTLP:
-                exporters.append((_EXPORTER_OTLP, _EXPORTER_OTLP_GRPC))
-            else:
-                exporters.append(
-                    (
-                        name,
-                        name,
-                    )
-                )
-        return exporters
-
-    @staticmethod
-    def _import_span_exporter_factories(
-        exporter_names: Collection[Tuple[str, str]],
-    ) -> Collection[_SpanExporterFactory]:
-        factories = []
-        entry_points = {
-            ep.name: ep for ep in iter_entry_points("opentelemetry_traces_exporter")
-        }
-
-        for name, internal_name in exporter_names:
-            if internal_name not in entry_points:
-                package = _KNOWN_EXPORTER_PACKAGES.get(internal_name)
-                if package:
-                    help_msg = f"please make sure {package} is installed"
-                else:
-                    help_msg = (
-                        "please make sure the relevant exporter package is installed."
-                    )
-                raise ValueError(
-                    f'exporter "{name} ({internal_name})" not found. {help_msg}'
-                )
-
-            exporter_class: _SpanExporterClass = entry_points[internal_name].load()
-            if internal_name == _EXPORTER_OTLP_GRPC:
-                factory = _Options._otlp_factory
-            else:
-                factory = _Options._generic_exporter
-            factories.append(partial(factory, exporter_class))
+def _get_span_exporter_factories(
+    factories: Optional[Collection[_SpanExporterFactory]],
+) -> Collection[_SpanExporterFactory]:
+    if factories:
         return factories
 
-    @staticmethod
-    def _generic_exporter(
-        exporter: _SpanExporterClass,
-        options: "_Options",  # pylint: disable=unused-argument
-    ) -> SpanExporter:
-        return exporter()
+    exporter_names = _get_span_exporter_names_from_env()
+    return _import_span_exporter_factories(exporter_names)
 
-    @staticmethod
-    def _otlp_factory(exporter: _SpanExporterClass, options: "_Options") -> SpanExporter:
-        return exporter(headers=(("x-sf-token", options.access_token),))
+
+def _is_truthy(value: Optional[str]) -> bool:
+    if not value:
+        return False
+
+    return value.strip().lower() not in (
+        "false",
+        "no",
+        "f",
+        "0",
+    )
+
+
+def _set_default_env() -> None:
+    defaults = {
+        OTEL_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
+        OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
+        OTEL_SPAN_EVENT_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
+        OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
+        OTEL_LINK_ATTRIBUTE_COUNT_LIMIT: _LIMIT_UNSET_VALUE,
+        OTEL_SPAN_LINK_COUNT_LIMIT: str(_DEFAULT_SPAN_LINK_COUNT_LIMIT),
+        OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT: str(_DEFAULT_MAX_ATTR_LENGTH),
+    }
+
+    for key, value in defaults.items():
+        if key not in environ:
+            environ[key] = value
+
+
+def _get_span_exporter_names_from_env() -> Collection[Tuple[str, str]]:
+    exporters_env = (
+        environ.get(OTEL_TRACES_EXPORTER, "").strip() or _DEFAULT_EXPORTERS
+    )
+
+    exporters: List[Tuple[str, str]] = []
+    if not _is_truthy(exporters_env):
+        return exporters
+
+    # exporters are known by different names internally by Python Otel SDK.
+    # Here we create a mapping of user provided names to internal names so
+    # that we can provide helpful error messages later.
+    for name in exporters_env.split(","):
+        if name == _EXPORTER_OTLP:
+            exporters.append((_EXPORTER_OTLP, _EXPORTER_OTLP_GRPC))
+        else:
+            exporters.append(
+                (
+                    name,
+                    name,
+                )
+            )
+    return exporters
+
+
+def _import_span_exporter_factories(
+    exporter_names: Collection[Tuple[str, str]],
+) -> Collection[_SpanExporterFactory]:
+    factories = []
+    entry_points = {
+        ep.name: ep for ep in iter_entry_points("opentelemetry_traces_exporter")
+    }
+
+    for name, internal_name in exporter_names:
+        if internal_name not in entry_points:
+            package = _KNOWN_EXPORTER_PACKAGES.get(internal_name)
+            if package:
+                help_msg = f"please make sure {package} is installed"
+            else:
+                help_msg = (
+                    "please make sure the relevant exporter package is installed."
+                )
+            raise ValueError(
+                f'exporter "{name} ({internal_name})" not found. {help_msg}'
+            )
+
+        exporter_class: _SpanExporterClass = entry_points[internal_name].load()
+        if internal_name == _EXPORTER_OTLP_GRPC:
+            factory = _otlp_factory
+        else:
+            factory = _generic_exporter
+        factories.append(partial(factory, exporter_class))
+    return factories
+
+
+def _generic_exporter(
+    exporter: _SpanExporterClass,
+    options: "_Options",  # pylint: disable=unused-argument
+) -> SpanExporter:
+    return exporter()
+
+
+def _otlp_factory(exporter: _SpanExporterClass, options: "_Options") -> SpanExporter:
+    return exporter(headers=(("x-sf-token", options.access_token),))

--- a/splunk_otel/options.py
+++ b/splunk_otel/options.py
@@ -127,9 +127,7 @@ def _create_resource(
         == _DEFAULT_OTEL_SERVICE_NAME
     ):
         logger.warning(_NO_SERVICE_NAME_WARNING)
-        resource = resource.merge(
-            Resource({_SERVICE_NAME_ATTR: _DEFAULT_SERVICE_NAME})
-        )
+        resource = resource.merge(Resource({_SERVICE_NAME_ATTR: _DEFAULT_SERVICE_NAME}))
     return resource
 
 
@@ -160,9 +158,7 @@ def _set_default_env() -> None:
 
 
 def _get_span_exporter_names_from_env() -> Collection[Tuple[str, str]]:
-    exporters_env = (
-        environ.get(OTEL_TRACES_EXPORTER, "").strip() or _DEFAULT_EXPORTERS
-    )
+    exporters_env = environ.get(OTEL_TRACES_EXPORTER, "").strip() or _DEFAULT_EXPORTERS
 
     exporters: List[Tuple[str, str]] = []
     if not _is_truthy_str(exporters_env):
@@ -198,12 +194,8 @@ def _import_span_exporter_factories(
             if package:
                 help_msg = f"please make sure {package} is installed"
             else:
-                help_msg = (
-                    "please make sure the relevant exporter package is installed."
-                )
-            raise ValueError(
-                f'exporter "{name} ({internal_name})" not found. {help_msg}'
-            )
+                help_msg = "please make sure the relevant exporter package is installed."
+            raise ValueError(f'exporter "{name} ({internal_name})" not found. {help_msg}')
 
         exporter_class: _SpanExporterClass = entry_points[internal_name].load()
         if internal_name == _EXPORTER_OTLP_GRPC:

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -410,9 +410,7 @@ def start_profiling(
     endpoint: Optional[str] = None,
     call_stack_interval_millis: Optional[int] = None,
 ):
-    resource = _create_resource(
-        service_name, resource_attributes
-    )
+    resource = _create_resource(service_name, resource_attributes)
     opts = _Options(resource, endpoint, call_stack_interval_millis)
     _start_profiling(opts)
 

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -35,7 +35,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.trace import TraceFlags
 from opentelemetry.trace.propagation import _SPAN_KEY
 
-from splunk_otel.options import _get_resource
+from splunk_otel.options import _create_resource
 from splunk_otel.profiling import profile_pb2
 from splunk_otel.profiling.options import _Options
 
@@ -410,7 +410,7 @@ def start_profiling(
     endpoint: Optional[str] = None,
     call_stack_interval_millis: Optional[int] = None,
 ):
-    resource = _get_resource(
+    resource = _create_resource(
         service_name, resource_attributes
     )
     opts = _Options(resource, endpoint, call_stack_interval_millis)

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -35,7 +35,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.trace import TraceFlags
 from opentelemetry.trace.propagation import _SPAN_KEY
 
-import splunk_otel
+from splunk_otel.options import _get_resource
 from splunk_otel.profiling import profile_pb2
 from splunk_otel.profiling.options import _Options
 
@@ -410,8 +410,7 @@ def start_profiling(
     endpoint: Optional[str] = None,
     call_stack_interval_millis: Optional[int] = None,
 ):
-    # pylint: disable-next=protected-access
-    resource = splunk_otel.options._Options._get_resource(
+    resource = _get_resource(
         service_name, resource_attributes
     )
     opts = _Options(resource, endpoint, call_stack_interval_millis)

--- a/splunk_otel/util.py
+++ b/splunk_otel/util.py
@@ -14,13 +14,7 @@
 
 import logging
 import os
-from typing import Any
-
-
-def _is_truthy(value: Any) -> bool:
-    if isinstance(value, str):
-        value = value.lower().strip()
-    return value in [True, 1, "true", "yes"]
+from typing import Any, Optional
 
 
 def _get_log_level(level):
@@ -41,3 +35,21 @@ def _init_logger(name):
     logger = logging.getLogger(name)
     logger.setLevel(level)
     logger.addHandler(logging.StreamHandler())
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        value = value.lower().strip()
+    return value in [True, 1, "true", "yes"]
+
+
+def _is_truthy_str(s: Optional[str]) -> bool:
+    if not s:
+        return False
+
+    return s.strip().lower() not in (
+        "false",
+        "no",
+        "f",
+        "0",
+    )

--- a/splunk_otel/util.py
+++ b/splunk_otel/util.py
@@ -43,11 +43,11 @@ def _is_truthy(value: Any) -> bool:
     return value in [True, 1, "true", "yes"]
 
 
-def _is_truthy_str(s: Optional[str]) -> bool:
-    if not s:
+def _is_truthy_str(value: Optional[str]) -> bool:
+    if not value:
         return False
 
-    return s.strip().lower() not in (
+    return value.strip().lower() not in (
         "false",
         "no",
         "f",

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -20,14 +20,14 @@ from requests_futures.sessions import FuturesSession
 from .conftest import IntegrationSession
 
 
-def _test_simple(integration: IntegrationSession, exporter: str):
+def test_otlp_simple(integration: IntegrationSession):
     session = FuturesSession()
     # start polling collector for spans
     future = session.get(integration.poll_url)
 
     # execute instrumented program
     env = os.environ.copy()
-    env["OTEL_TRACES_EXPORTER"] = exporter
+    env["OTEL_TRACES_EXPORTER"] = "otlp"
     subprocess.check_call(
         ["python", f"{integration.rootdir}/simple/main.py"],
         stdout=subprocess.DEVNULL,
@@ -50,7 +50,3 @@ def _test_simple(integration: IntegrationSession, exporter: str):
     ]
     for tag in tags:
         assert tag in span["tags"]
-
-
-def test_otlp_simple(integration: IntegrationSession):
-    _test_simple(integration, exporter="otlp")


### PR DESCRIPTION
This change reorganizes and renames some functions, mostly to replace statements like `splunk_otel.options._Options._get_resource()` with simpler statements like e.g. `_create_resource()`.