### PR TITLE
Include github actions updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     labels:
       - "Skip Changelog"
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Skip Changelog"
+      - "dependencies"
+


### PR DESCRIPTION
The build is currently failing due to an outdated link checker.  Looking deeper, dependabot wasn't configured to update github actions, so fix that underlying cause first.  This will probably generate some new PRs for the actions once it lands.