### PR TITLE
Return no-op instead of exiting if tracing can't start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changed the return type of start_tracing from sdk.TracerProvider to api.TracerProvider
+
 ## 1.17.0 - 2024-01-22
 - Dependencies bump, removed Jaeger
 

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -22,8 +22,7 @@ from opentelemetry.instrumentation.environment_variables import (
     OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
 )
 from opentelemetry.instrumentation.propagators import set_global_response_propagator
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace import NoOpTracerProvider
+from opentelemetry.sdk.trace import NoOpTracerProvider, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from pkg_resources import iter_entry_points
 

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -14,7 +14,6 @@
 
 import logging
 import os
-import sys
 from typing import Collection, Dict, Optional, Union
 
 from opentelemetry import trace

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -23,6 +23,7 @@ from opentelemetry.instrumentation.environment_variables import (
 )
 from opentelemetry.instrumentation.propagators import set_global_response_propagator
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import NoOpTracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from pkg_resources import iter_entry_points
 
@@ -55,8 +56,9 @@ def start_tracing(
         provider = _configure_tracing(options)
         _load_instrumentors()
         return provider
-    except Exception:  # pylint:disable=broad-except
-        sys.exit(2)
+    except Exception as error:  # pylint:disable=broad-except
+        logger.error("tracing could not be enabled: %s", error)
+        return NoOpTracerProvider()
 
 
 def _configure_tracing(options: _Options) -> TracerProvider:

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -22,7 +22,6 @@ from opentelemetry.instrumentation.environment_variables import (
     OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
 )
 from opentelemetry.instrumentation.propagators import set_global_response_propagator
-from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from pkg_resources import iter_entry_points
@@ -39,7 +38,7 @@ def start_tracing(
     access_token: Optional[str] = None,
     resource_attributes: Optional[Dict[str, Union[str, bool, int, float]]] = None,
     trace_response_header_enabled: Optional[bool] = None,
-) -> trace_api.TracerProvider:
+) -> trace.TracerProvider:
     enabled = os.environ.get("OTEL_TRACE_ENABLED", True)
     if not _is_truthy(enabled):
         logger.info("tracing has been disabled with OTEL_TRACE_ENABLED=%s", enabled)
@@ -58,7 +57,7 @@ def start_tracing(
         return provider
     except Exception as error:  # pylint:disable=broad-except
         logger.error("tracing could not be enabled: %s", error)
-        return trace_api.NoOpTracerProvider()
+        return trace.NoOpTracerProvider()
 
 
 def _configure_tracing(options: _Options) -> TracerProvider:

--- a/splunk_otel/tracing.py
+++ b/splunk_otel/tracing.py
@@ -22,7 +22,8 @@ from opentelemetry.instrumentation.environment_variables import (
     OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
 )
 from opentelemetry.instrumentation.propagators import set_global_response_propagator
-from opentelemetry.sdk.trace import NoOpTracerProvider, TracerProvider
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from pkg_resources import iter_entry_points
 
@@ -38,7 +39,7 @@ def start_tracing(
     access_token: Optional[str] = None,
     resource_attributes: Optional[Dict[str, Union[str, bool, int, float]]] = None,
     trace_response_header_enabled: Optional[bool] = None,
-) -> TracerProvider:
+) -> trace_api.TracerProvider:
     enabled = os.environ.get("OTEL_TRACE_ENABLED", True)
     if not _is_truthy(enabled):
         logger.info("tracing has been disabled with OTEL_TRACE_ENABLED=%s", enabled)
@@ -57,7 +58,7 @@ def start_tracing(
         return provider
     except Exception as error:  # pylint:disable=broad-except
         logger.error("tracing could not be enabled: %s", error)
-        return NoOpTracerProvider()
+        return trace_api.NoOpTracerProvider()
 
 
 def _configure_tracing(options: _Options) -> TracerProvider:


### PR DESCRIPTION
If tracing can't start for some reason, print an error message and return a no-op implementation, rather than calling `exit()`.  You know, so the instrumented app can keep running.