### PR TITLE
fix: reported frame count for profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changed the return type of start_tracing from sdk.TracerProvider to api.TracerProvider
+- Profiling: fix the reported frame count when exporting stacktraces.
 
 ## 1.17.0 - 2024-01-22
 - Dependencies bump, removed Jaeger

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -137,6 +137,10 @@ class Profiler:
         encoded = self.get_cpu_profile(stacktraces, timestamp_unix_nanos)
         encoded_profile = base64.b64encode(encoded).decode()
 
+        frame_count = 0
+        for stacktrace in stacktraces:
+            frame_count = frame_count + len(stacktrace["frames"])
+
         return LogRecord(
             timestamp=timestamp_unix_nanos,
             trace_id=0,
@@ -149,7 +153,7 @@ class Profiler:
                 "profiling.data.format": "pprof-gzip-base64",
                 "profiling.data.type": "cpu",
                 "com.splunk.sourcetype": "otel.profiling",
-                "profiling.data.total.frame.count": len(stacktraces),
+                "profiling.data.total.frame.count": frame_count,
             },
         )
 
@@ -238,7 +242,7 @@ class Profiler:
 
             location_ids = []
 
-            for frame in reversed(stacktrace["stacktrace"]):
+            for frame in reversed(stacktrace["frames"]):
                 location_ids.append(get_location(frame).id)
 
             sample.location_id.extend(location_ids)
@@ -351,7 +355,7 @@ def _collect_stacktraces(ignored_thread_ids):
         for sf in stack:
             stacktrace_frames.append((sf.filename, sf.name, sf.lineno))
         stacktrace = {
-            "stacktrace": stacktrace_frames,
+            "frames": stacktrace_frames,
             "tid": thread_id,
         }
         stacktraces.append(stacktrace)

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -139,7 +139,7 @@ class Profiler:
 
         frame_count = 0
         for stacktrace in stacktraces:
-            frame_count = frame_count + len(stacktrace["frames"])
+            frame_count += len(stacktrace["frames"])
 
         return LogRecord(
             timestamp=timestamp_unix_nanos,

--- a/tests/unit/test_profiling.py
+++ b/tests/unit/test_profiling.py
@@ -129,8 +129,8 @@ class TestProfiling(unittest.TestCase):
         self.assertEqual(attributes["profiling.data.format"], "pprof-gzip-base64")
         self.assertEqual(attributes["profiling.data.type"], "cpu")
         self.assertEqual(attributes["com.splunk.sourcetype"], "otel.profiling")
-        # We should at least have the main thread
-        self.assertGreaterEqual(attributes["profiling.data.total.frame.count"], 1)
+        # We should at least have a few frames from the main thread
+        self.assertGreaterEqual(attributes["profiling.data.total.frame.count"], 10)
 
         resource = log_record.resource.attributes
 


### PR DESCRIPTION
Profiling should report the total number of stacktrace frames not the count of stacktraces.