### PR TITLE
profiling: fix span context access for non recording spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Profiling: fix access to context in case of `NonRecordingSpan`.
+
 ## 1.18.0 - 2024-03-06
 - Upgraded Otel dependencies to 1.23.0 / 0.44b0
 

--- a/splunk_otel/profiling/__init__.py
+++ b/splunk_otel/profiling/__init__.py
@@ -275,9 +275,10 @@ class Profiler:
 
                 if span:
                     thread_id = threading.get_ident()
+                    context = span.get_span_context()
                     self.thread_states[thread_id] = (
-                        span.context.trace_id,
-                        span.context.span_id,
+                        context.trace_id,
+                        context.span_id,
                     )
 
             return token
@@ -295,9 +296,10 @@ class Profiler:
                     span = prev.get(_SPAN_KEY)
 
                     if span:
+                        context = span.get_span_context()
                         self.thread_states[thread_id] = (
-                            span.context.trace_id,
-                            span.context.span_id,
+                            context.trace_id,
+                            context.span_id,
                         )
                     else:
                         self.thread_states[thread_id] = None


### PR DESCRIPTION
`NonRecordingSpan` does not have a `context` property, use `get_span_context` function instead.