### PR TITLE
Prepare release v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 1.20.0 - 2024-08-08
 - Upgrade Otel dependencies to 1.26.0 / 0.47b0
 
 ## 1.19.1 - 2024-05-29

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <span class="otel-version-badge"><a href="https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.24.0"><img alt="OpenTelemetry Python Version" src="https://img.shields.io/badge/otel-1.24.0-blueviolet?style=for-the-badge"/></a></span>
+  <span class="otel-version-badge"><a href="https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.26.0"><img alt="OpenTelemetry Python Version" src="https://img.shields.io/badge/otel-1.26.0-blueviolet?style=for-the-badge"/></a></span>
   <a href="https://github.com/signalfx/splunk-otel-python/releases">
     <img alt="GitHub release (latest SemVer)" src="https://img.shields.io/github/v/release/signalfx/splunk-otel-python?style=for-the-badge">
   </a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "splunk-opentelemetry"
-version = "1.19.1"
+version = "1.20.0"
 description = "The Splunk distribution of OpenTelemetry Python Instrumentation provides a Python agent that automatically instruments your Python application to capture and report distributed traces to SignalFx APM."
 authors = ["Splunk <splunk-oss@splunk.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bump upstream versions to 1.26.0 / 0.47b0.