### PR TITLE
Add configurator and oteltest job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,5 +41,8 @@ jobs:
     - name: Run unit tests with coverage
       run: hatch run cov
 
+    - name: Install oteltest
+      run: pip install oteltest
+
     - name: Run oteltests
       run: oteltest tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, v2]
   pull_request:
-    branches: [main, master]
+    branches: [main, v2]
 
 concurrency:
   group: test-${{ github.head_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,8 @@ jobs:
     - name: Run static analysis
       run: hatch fmt --check
 
-    - name: Run tests
+    - name: Run unit tests with coverage
       run: hatch run cov
+
+    - name: Run oteltests
+      run: oteltest tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,4 @@ jobs:
       run: pip install oteltest
 
     - name: Run oteltests
-      run: oteltest tests
+      run: oteltest tests/ott*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ Documentation = "https://github.com/signalfx/splunk-otel-python#readme"
 Issues = "https://github.com/signalfx/splunk-otel-python/issues"
 Source = "https://github.com/signalfx/splunk-otel-python"
 
-#[project.entry-points.opentelemetry_configurator]
-#configurator = "splunk_otel.configurator:SplunkConfigurator"
+[project.entry-points.opentelemetry_configurator]
+configurator = "splunk_otel.configurator:SplunkConfigurator"
 
 [project.entry-points.opentelemetry_distro]
 splunk_distro = "splunk_otel.distro:SplunkDistro"
@@ -54,6 +54,7 @@ dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
   "ruff",
+  "oteltest",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/src/splunk_otel/configurator.py
+++ b/src/splunk_otel/configurator.py
@@ -1,0 +1,19 @@
+#  Copyright Splunk Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from opentelemetry.sdk._configuration import _OTelSDKConfigurator
+
+
+class SplunkConfigurator(_OTelSDKConfigurator):
+    pass

--- a/tests/ott_trace_loop.py
+++ b/tests/ott_trace_loop.py
@@ -1,0 +1,42 @@
+import time
+from pathlib import Path
+
+from opentelemetry import trace
+from oteltest.telemetry import num_spans
+
+NUM_SPANS = 12
+
+
+def trace_loop(loops):
+    tracer = trace.get_tracer("my-tracer")
+    for i in range(loops):
+        with tracer.start_as_current_span("my-span"):
+            time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    trace_loop(NUM_SPANS)
+
+
+class MyOtelTest:
+    def requirements(self):
+        parent_dir = str(Path(__file__).parent.parent)
+        return parent_dir, "oteltest"
+
+    def environment_variables(self):
+        return {
+            "OTEL_SERVICE_NAME": "my-svc",
+        }
+
+    def wrapper_command(self):
+        return "opentelemetry-instrument"
+
+    def on_start(self):
+        return None
+
+    def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:
+        span_count = num_spans(telemetry)
+        assert span_count == NUM_SPANS
+
+    def is_http(self):
+        return False

--- a/tests/ott_trace_loop.py
+++ b/tests/ott_trace_loop.py
@@ -9,7 +9,7 @@ NUM_SPANS = 12
 
 def trace_loop(loops):
     tracer = trace.get_tracer("my-tracer")
-    for i in range(loops):
+    for _ in range(loops):
         with tracer.start_as_current_span("my-span"):
             time.sleep(0.5)
 
@@ -34,7 +34,7 @@ class MyOtelTest:
     def on_start(self):
         return None
 
-    def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:
+    def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:  # noqa: ARG002
         span_count = num_spans(telemetry)
         assert span_count == NUM_SPANS
 

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -11,9 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from importlib.metadata import entry_points
 
-from splunk_otel.distro import SplunkDistro, is_system_metrics_instrumentor
+from splunk_otel.distro import SplunkDistro
 from splunk_otel.env import Env
 
 

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -27,13 +27,3 @@ def test_distro_env():
     # spot check default env vars
     assert env_store["OTEL_TRACES_EXPORTER"] == "otlp"
     assert len(env_store) == 11
-
-
-def test_is_system_metrics_instrumentor():
-    eps = entry_points()
-
-    ep = eps.get("opentelemetry_instrumentor")[0]
-    assert is_system_metrics_instrumentor(ep)
-
-    distro_ep = eps.get("opentelemetry_distro")[0]
-    assert not is_system_metrics_instrumentor(distro_ep)


### PR DESCRIPTION
This change adds a `SplunkConfigurator` class which defers to upstream to perform OTel configuration. It also adds an oteltest github workflow job.