### PR TITLE
Add support for splunk access token env var

### DIFF
--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -16,8 +16,11 @@ import logging
 
 from opentelemetry.instrumentation.distro import BaseDistro
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_HEADERS
 
-from splunk_otel.env import DEFAULTS, OTEL_METRICS_ENABLED, Env
+from splunk_otel.env import DEFAULTS, OTEL_METRICS_ENABLED, SPLUNK_ACCESS_TOKEN, Env
+
+X_SF_TOKEN = "x-sf-token"  # noqa S105
 
 
 class SplunkDistro(BaseDistro):
@@ -32,10 +35,16 @@ class SplunkDistro(BaseDistro):
 
     def _configure(self, **kwargs):  # noqa: ARG002
         self.set_env_defaults()
+        self.configure_headers()
 
     def set_env_defaults(self):
         for key, value in DEFAULTS.items():
             self.env.setdefault(key, value)
+
+    def configure_headers(self):
+        tok = self.env.getval(SPLUNK_ACCESS_TOKEN)
+        if tok:
+            self.env.list_append(OTEL_EXPORTER_OTLP_HEADERS, f"{X_SF_TOKEN}={tok}")
 
     def load_instrumentor(self, entry_point, **kwargs):
         #  This method is called in a loop by opentelemetry-instrumentation

--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -42,7 +42,7 @@ class SplunkDistro(BaseDistro):
             self.env.setdefault(key, value)
 
     def configure_headers(self):
-        tok = self.env.getval(SPLUNK_ACCESS_TOKEN)
+        tok = self.env.getval(SPLUNK_ACCESS_TOKEN).strip()
         if tok:
             self.env.list_append(OTEL_EXPORTER_OTLP_HEADERS, f"{X_SF_TOKEN}={tok}")
 

--- a/tests/ott_lib.py
+++ b/tests/ott_lib.py
@@ -1,0 +1,15 @@
+import time
+from pathlib import Path
+
+from opentelemetry import trace
+
+
+def project_path():
+    return str(Path(__file__).parent.parent)
+
+
+def trace_loop(loops):
+    tracer = trace.get_tracer("my-tracer")
+    for _ in range(loops):
+        with tracer.start_as_current_span("my-span"):
+            time.sleep(0.5)

--- a/tests/ott_sf_token.py
+++ b/tests/ott_sf_token.py
@@ -1,19 +1,18 @@
-from oteltest.telemetry import num_spans
+from oteltest import Telemetry
 from ott_lib import project_path, trace_loop
 
-NUM_SPANS = 12
-
 if __name__ == "__main__":
-    trace_loop(NUM_SPANS)
+    trace_loop(12)
 
 
-class NumSpansOtelTest:
+class AccessTokenOtelTest:
     def requirements(self):
         return project_path(), "oteltest"
 
     def environment_variables(self):
         return {
             "OTEL_SERVICE_NAME": "my-svc",
+            "SPLUNK_ACCESS_TOKEN": "s3cr3t",
         }
 
     def wrapper_command(self):
@@ -22,8 +21,9 @@ class NumSpansOtelTest:
     def on_start(self):
         return None
 
-    def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:  # noqa: ARG002
-        assert num_spans(telemetry) == NUM_SPANS
+    def on_stop(self, telemetry: Telemetry, stdout: str, stderr: str, returncode: int) -> None:  # noqa: ARG002
+        for request in telemetry.get_trace_requests():
+            assert request.headers.get("x-sf-token") == "s3cr3t"
 
     def is_http(self):
         return False

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -26,3 +26,11 @@ def test_distro_env():
     # spot check default env vars
     assert env_store["OTEL_TRACES_EXPORTER"] == "otlp"
     assert len(env_store) == 11
+
+
+def test_access_token():
+    env_store = {"SPLUNK_ACCESS_TOKEN": "abc123"}
+    sd = SplunkDistro()
+    sd.env = Env(env_store)
+    sd.configure()
+    assert env_store["OTEL_EXPORTER_OTLP_HEADERS"] == "x-sf-token=abc123"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -18,19 +18,36 @@ from splunk_otel.env import Env
 
 def test_distro_env():
     env_store = {}
-    # SplunkDistro's parent prevents passing in a constructor arg...
-    sd = SplunkDistro()
-    # ...so instead we overwrite the field right after construction
-    sd.env = Env(env_store)
-    sd.configure()
-    # spot check default env vars
+    configure_distro(env_store)
     assert env_store["OTEL_TRACES_EXPORTER"] == "otlp"
     assert len(env_store) == 11
 
 
 def test_access_token():
     env_store = {"SPLUNK_ACCESS_TOKEN": "abc123"}
+    configure_distro(env_store)
+    assert env_store["OTEL_EXPORTER_OTLP_HEADERS"] == "x-sf-token=abc123"
+
+
+def test_access_token_none():
+    env_store = {}
+    configure_distro(env_store)
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env_store
+
+
+def test_access_token_empty():
+    env_store = {"SPLUNK_ACCESS_TOKEN": ""}
+    configure_distro(env_store)
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env_store
+
+
+def test_access_token_whitespace():
+    env_store = {"SPLUNK_ACCESS_TOKEN": " "}
+    configure_distro(env_store)
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in env_store
+
+
+def configure_distro(env_store):
     sd = SplunkDistro()
     sd.env = Env(env_store)
     sd.configure()
-    assert env_store["OTEL_EXPORTER_OTLP_HEADERS"] == "x-sf-token=abc123"


### PR DESCRIPTION
This change adds support for setting the `x-sf-token` request header with the value from SPLUNK_ACCESS_TOKEN.