### PR TITLE
Add init_otel() function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,9 +13,9 @@ Summary of changes between Splunk OTel Python major versions 1 and 2.
 
 ### Version 2
 
-| Function name  | Operation                             | Arguments |
-|----------------|---------------------------------------|-----------|
-| `start_otel()` | Configures tracing, metrics, and logs | None      |
+| Function name | Operation                              | Arguments |
+|---------------|----------------------------------------|-----------|
+| `init_otel()` | Initializes tracing, metrics, and logs | None      |
 
 ## Environment Variables
 

--- a/src/splunk_otel/__init__.py
+++ b/src/splunk_otel/__init__.py
@@ -11,4 +11,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from splunk_otel.configurator import SplunkConfigurator
+from splunk_otel.distro import SplunkDistro
 
+
+def init_otel():
+    """
+    Initializes OpenTelemetry Python components (exporters, tracer providers, meter providers, resources etc.).
+    Like auto instrumentation (`opentelemetry-instrument`) but without loading instrumentors.
+    """
+    sd = SplunkDistro()
+    sd.configure()
+    sc = SplunkConfigurator()
+    sc.configure()

--- a/src/splunk_otel/__init__.py
+++ b/src/splunk_otel/__init__.py
@@ -15,7 +15,7 @@ from splunk_otel.configurator import SplunkConfigurator
 from splunk_otel.distro import SplunkDistro
 
 
-def init_otel():
+def init_splunk_otel():
     """
     Initializes OpenTelemetry Python components (exporters, tracer providers, meter providers, resources etc.).
     Like auto instrumentation (`opentelemetry-instrument`) but without loading instrumentors.

--- a/tests/ott_init_otel.py
+++ b/tests/ott_init_otel.py
@@ -1,0 +1,32 @@
+from typing import Mapping, Optional, Sequence
+
+from oteltest.telemetry import count_spans
+from ott_lib import project_path, trace_loop
+
+NUM_SPANS = 12
+
+if __name__ == "__main__":
+    from splunk_otel import init_otel
+
+    init_otel()
+    trace_loop(NUM_SPANS)
+
+
+class ConfigureOtelTest:
+    def environment_variables(self) -> Mapping[str, str]:
+        return {}
+
+    def requirements(self) -> Sequence[str]:
+        return [project_path(), "oteltest"]
+
+    def wrapper_command(self) -> str:
+        return ""
+
+    def on_start(self) -> Optional[float]:
+        pass
+
+    def on_stop(self, tel, stdout: str, stderr: str, returncode: int) -> None:
+        assert count_spans(tel) == NUM_SPANS
+
+    def is_http(self) -> bool:
+        return False

--- a/tests/ott_init_otel.py
+++ b/tests/ott_init_otel.py
@@ -6,9 +6,9 @@ from ott_lib import project_path, trace_loop
 NUM_SPANS = 12
 
 if __name__ == "__main__":
-    from splunk_otel import init_otel
+    from splunk_otel import init_splunk_otel
 
-    init_otel()
+    init_splunk_otel()
     trace_loop(NUM_SPANS)
 
 


### PR DESCRIPTION
This is like the `start_tracing` function in v1 but uses upstream's logic to initialize/configure components. Like before, does not load instrumentors (except for the system metric instrumentor which we're bundling).