### PR TITLE
Update deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,14 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "cryptography>=2.0,<=42.0.8",
-  "protobuf>=4.23,<5.0",
-  "opentelemetry-api==1.27.0",
-  "opentelemetry-sdk==1.27.0",
-  "opentelemetry-propagator-b3==1.27.0",
-  "opentelemetry-exporter-otlp-proto-grpc==1.27.0",
-  "opentelemetry-exporter-otlp-proto-http==1.27.0",
-  "opentelemetry-instrumentation==0.48b0",
-  "opentelemetry-instrumentation-system-metrics==0.48b0",
-  "opentelemetry-semantic-conventions==0.48b0",
+  "opentelemetry-api==1.28.2",
+  "opentelemetry-sdk==1.28.2",
+  "opentelemetry-propagator-b3==1.28.2",
+  "opentelemetry-exporter-otlp-proto-grpc==1.28.2",
+  "opentelemetry-exporter-otlp-proto-http==1.28.2",
+  "opentelemetry-instrumentation==0.49b2",
+  "opentelemetry-instrumentation-system-metrics==0.49b2",
+  "opentelemetry-semantic-conventions==0.49b2",
 ]
 
 [project.urls]

--- a/tests/ott_propagator.py
+++ b/tests/ott_propagator.py
@@ -35,8 +35,7 @@ class OTT(OtelTest):
             project_path(),
             "oteltest",
             "flask",
-            "opentelemetry-instrumentation-flask==0.48b0",
-            "opentelemetry-exporter-otlp-proto-grpc==1.27.0",
+            "opentelemetry-instrumentation-flask",
         ]
 
     def wrapper_command(self) -> str:


### PR DESCRIPTION
Bump upstream otel versions
Remove cryptography library (from v1, not used?)
Remove protobuf library (version pin conflicted with upstream)
