### PR TITLE
Add telemetry resource attrs

### DIFF
--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -71,16 +71,16 @@ class SplunkDistro(BaseDistro):
         if tok:
             self.env.list_append(OTEL_EXPORTER_OTLP_HEADERS, f"{X_SF_TOKEN}={tok}")
 
+    def set_server_timing_propagator(self):
+        if self.env.is_true(SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true"):
+            set_global_response_propagator(ServerTimingResponsePropagator())
+
     def load_instrumentor(self, entry_point, **kwargs):
         #  This method is called in a loop by opentelemetry-instrumentation
         if is_system_metrics_instrumentor(entry_point) and not self.env.is_true(OTEL_METRICS_ENABLED):
             self.logger.info("%s not set -- skipping SystemMetricsInstrumentor", OTEL_METRICS_ENABLED)
         else:
             super().load_instrumentor(entry_point, **kwargs)
-
-    def set_server_timing_propagator(self):
-        if self.env.is_true(SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true"):
-            set_global_response_propagator(ServerTimingResponsePropagator())
 
 
 def is_system_metrics_instrumentor(entry_point):

--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -20,9 +20,17 @@ from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrument
 from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_HEADERS, OTEL_RESOURCE_ATTRIBUTES
 
 from splunk_otel.__about__ import __version__ as version
-from splunk_otel.env import (DEFAULTS, Env, OTEL_LOGS_ENABLED, OTEL_METRICS_ENABLED,
-                             OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, SPLUNK_ACCESS_TOKEN,
-                             SPLUNK_PROFILER_ENABLED, SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, X_SF_TOKEN)
+from splunk_otel.env import (
+    DEFAULTS,
+    OTEL_LOGS_ENABLED,
+    OTEL_METRICS_ENABLED,
+    OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+    SPLUNK_ACCESS_TOKEN,
+    SPLUNK_PROFILER_ENABLED,
+    SPLUNK_TRACE_RESPONSE_HEADER_ENABLED,
+    X_SF_TOKEN,
+    Env,
+)
 from splunk_otel.propagator import ServerTimingResponsePropagator
 
 DISTRO_NAME = "splunk-opentelemetry"

--- a/tests/ott_spec.py
+++ b/tests/ott_spec.py
@@ -1,4 +1,7 @@
+from oteltest.telemetry import extract_leaves, get_attribute
+
 from ott_lib import project_path, trace_loop
+from splunk_otel.__about__ import __version__ as version
 
 if __name__ == "__main__":
     trace_loop(1)
@@ -6,12 +9,10 @@ if __name__ == "__main__":
 
 class SpecOtelTest:
     def requirements(self):
-        return (project_path(),)
+        return project_path(), "oteltest"
 
     def environment_variables(self):
-        return {
-            "OTEL_SERVICE_NAME": "my-svc",
-        }
+        return {"OTEL_SERVICE_NAME": "my-svc"}
 
     def wrapper_command(self):
         return "opentelemetry-instrument"
@@ -20,13 +21,18 @@ class SpecOtelTest:
         return None
 
     def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:
-        from oteltest.telemetry import extract_leaves, get_attribute
-
         attributes = extract_leaves(telemetry, "trace_requests", "pbreq", "resource_spans", "resource", "attributes")
 
         assert get_attribute(attributes, "telemetry.sdk.name")
         assert get_attribute(attributes, "telemetry.sdk.version")
         assert get_attribute(attributes, "telemetry.sdk.language")
 
+        assert get_attribute_str(attributes, "telemetry.distro.name") == "splunk-opentelemetry"
+        assert get_attribute_str(attributes, "telemetry.distro.version") == version
+
     def is_http(self):
         return False
+
+
+def get_attribute_str(attributes, key):
+    return get_attribute(attributes, key).value.string_value

--- a/tests/ott_spec.py
+++ b/tests/ott_spec.py
@@ -1,6 +1,5 @@
 from oteltest.telemetry import extract_leaves, get_attribute
 from ott_lib import project_path, trace_loop
-from splunk_otel.__about__ import __version__ as version
 
 if __name__ == "__main__":
     trace_loop(1)
@@ -26,8 +25,8 @@ class SpecOtelTest:
         assert get_attribute(attributes, "telemetry.sdk.version")
         assert get_attribute(attributes, "telemetry.sdk.language")
 
+        assert get_attribute_str(attributes, "telemetry.distro.version")
         assert get_attribute_str(attributes, "telemetry.distro.name") == "splunk-opentelemetry"
-        assert get_attribute_str(attributes, "telemetry.distro.version") == version
 
     def is_http(self):
         return False

--- a/tests/ott_spec.py
+++ b/tests/ott_spec.py
@@ -1,5 +1,4 @@
 from oteltest.telemetry import extract_leaves, get_attribute
-
 from ott_lib import project_path, trace_loop
 from splunk_otel.__about__ import __version__ as version
 

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from opentelemetry.instrumentation.propagators import get_global_response_propagator, set_global_response_propagator
-
 from splunk_otel.__about__ import __version__ as version
 from splunk_otel.distro import SplunkDistro
 from splunk_otel.env import Env

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from opentelemetry.instrumentation.propagators import get_global_response_propagator, set_global_response_propagator
+
+from splunk_otel.__about__ import __version__ as version
 from splunk_otel.distro import SplunkDistro
 from splunk_otel.env import Env
 
@@ -87,6 +89,15 @@ def test_profiling_notset():
     configure_distro(env_store)
     assert "OTEL_LOGS_ENABLED" not in env_store
     assert "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED" not in env_store
+
+
+def test_resource_attributes():
+    env_store = {"OTEL_RESOURCE_ATTRIBUTES": "foo=bar"}
+    configure_distro(env_store)
+    attrs = env_store["OTEL_RESOURCE_ATTRIBUTES"]
+    assert "telemetry.distro.name=splunk-opentelemetry" in attrs
+    assert f"telemetry.distro.version={version}" in attrs
+    assert "foo=bar" in attrs
 
 
 def configure_distro(env_store):

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -21,7 +21,7 @@ def test_distro_env():
     env_store = {}
     configure_distro(env_store)
     assert env_store["OTEL_TRACES_EXPORTER"] == "otlp"
-    assert len(env_store) == 14
+    assert len(env_store) > 10
 
 
 def test_access_token():


### PR DESCRIPTION
Addresses part of https://github.com/signalfx/splunk-otel-python/issues/557

> - SHOULD set the following resource attributes when applicable:
>   - `telemetry.distro.name`
>   - `telemetry.distro.version`