### PR TITLE
Profiling fixes

### DIFF
--- a/src/splunk_otel/profile.py
+++ b/src/splunk_otel/profile.py
@@ -20,14 +20,19 @@ from opentelemetry.trace import TraceFlags
 from opentelemetry.trace.propagation import _SPAN_KEY
 
 from splunk_otel import profile_pb2
-from splunk_otel.env import SPLUNK_PROFILER_CALL_STACK_INTERVAL, SPLUNK_PROFILER_ENABLED, Env
+from splunk_otel.env import (
+    SPLUNK_PROFILER_CALL_STACK_INTERVAL,
+    SPLUNK_PROFILER_ENABLED,
+    Env,
+)
 
 _DEFAULT_PROF_CALL_STACK_INTERVAL_MILLIS = 1000
-
 _SERVICE_NAME_ATTR = "service.name"
 _SPLUNK_DISTRO_VERSION_ATTR = "splunk.distro.version"
+_SCOPE_VERSION = "0.1.0"
+_SCOPE_NAME = "otel.profiling"
 
-_profile_timer = None
+_timer = None
 _pylogger = logging.getLogger(__name__)
 
 
@@ -46,16 +51,16 @@ def start_profiling(env=None):
     tcm.wrap_context_methods()
 
     resource = _mk_resource(svcname)
-    logger = get_logger("splunk-profiler")
+    logger = get_logger(_SCOPE_NAME, _SCOPE_VERSION)
     scraper = _ProfileScraper(resource, tcm.get_thread_states(), interval_millis, logger)
 
-    global _profile_timer  # noqa PLW0603
-    _profile_timer = _IntervalTimer(interval_millis, scraper.tick)
-    _profile_timer.start()
+    global _timer  # noqa PLW0603
+    _timer = _IntervalTimer(interval_millis, scraper.tick)
+    _timer.start()
 
 
 def stop_profiling():
-    _profile_timer.stop()
+    _timer.stop()
 
 
 def _mk_resource(service_name) -> Resource:
@@ -127,8 +132,10 @@ class _ThreadContextMapping:
 def _collect_stacktraces():
     out = []
     frames = sys._current_frames()  # noqa SLF001
-
+    profile_scraper_thread_id = threading.get_ident()
     for thread_id, frame in frames.items():
+        if thread_id == profile_scraper_thread_id:
+            continue
         stack_summary = _extract_stack_summary(frame)
         frames = [(sf.filename, sf.name, sf.lineno) for sf in stack_summary]
         out.append(

--- a/src/splunk_otel/profile.py
+++ b/src/splunk_otel/profile.py
@@ -29,7 +29,7 @@ from splunk_otel.env import (
 _DEFAULT_PROF_CALL_STACK_INTERVAL_MILLIS = 1000
 _SERVICE_NAME_ATTR = "service.name"
 _SPLUNK_DISTRO_VERSION_ATTR = "splunk.distro.version"
-_SCOPE_VERSION = "0.1.0"
+_SCOPE_VERSION = "0.2.0"
 _SCOPE_NAME = "otel.profiling"
 
 _timer = None

--- a/tests/ott_profile.py
+++ b/tests/ott_profile.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
 class ProfileOtelTest:
     def environment_variables(self):
         return {
+            "OTEL_SERVICE_NAME": __file__,
             "SPLUNK_PROFILER_ENABLED": "true",
             "SPLUNK_PROFILER_CALL_STACK_INTERVAL": "500",  # not necessary, defaults to "1000" (ms)
             "SPLUNK_PROFILER_LOGS_ENDPOINT": "http://localhost:4317",  # not necessary, this is the default
@@ -18,14 +19,16 @@ class ProfileOtelTest:
     def wrapper_command(self):
         return "opentelemetry-instrument"
 
+    def is_http(self):
+        return False
+
     def on_start(self):
         pass
 
     def on_stop(self, tel, stdout: str, stderr: str, returncode: int):
-        from oteltest.telemetry import count_logs, has_log_attribute
+        from oteltest.telemetry import extract_leaves, get_attribute
 
-        assert count_logs(tel)
-        assert has_log_attribute(tel, "profiling.data.format")
-
-    def is_http(self):
-        return False
+        scope_logs = extract_leaves(tel, "log_requests", "pbreq", "resource_logs", "scope_logs")
+        profiling_scope_logs = [scope_log for scope_log in scope_logs if scope_log.scope.name == "otel.profiling"]
+        fmt_attr = get_attribute(profiling_scope_logs[0].log_records[0].attributes, "profiling.data.format")
+        assert fmt_attr.value.string_value == "pprof-gzip-base64"

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -10,7 +10,11 @@ from google.protobuf.json_format import MessageToDict
 from opentelemetry._logs import Logger
 from opentelemetry.sdk.resources import Resource
 from splunk_otel import profile_pb2
-from splunk_otel.profile import _pb_profile_to_str, _ProfileScraper, _stacktraces_to_cpu_profile
+from splunk_otel.profile import (
+    _pb_profile_to_str,
+    _ProfileScraper,
+    _stacktraces_to_cpu_profile,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
Ignore profile scraper thread.
Set logger scope name and version to the right values (required by the Splunk HEC exporter).