### PR TITLE
Set gitlab ci image to python-slim

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 default:
-  image: 'cimg/python:3.11'
+  image: 'python:3.11-slim'
 
 include:
   - project: core-ee/signing/api-integration


### PR DESCRIPTION
Addressing permission denied when running apt. The python-slim image runs as root by default.