### PR TITLE
Restrict protobuf and bump our version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "opentelemetry-instrumentation==0.56b0",
   "opentelemetry-instrumentation-system-metrics==0.56b0",
   "opentelemetry-semantic-conventions==0.56b0",
+  "protobuf>=6.31.1", # not our direct dep, prevents installing vulnerable proto versions (CVE‑2025‑4565)
 ]
 
 [project.urls]

--- a/src/splunk_otel/__about__.py
+++ b/src/splunk_otel/__about__.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"


### PR DESCRIPTION
Restrict protobuf to 6.31.1 or higher to address CVE-2025-4565.

Bump our version to 2.6.0.