### PR TITLE
Remove MacOS CI runners as they are flaky

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
MacOS CI runs have been failing lately (possible psutil compatibility issue). Removing MacOS runners until the problem is resolved.