### PR TITLE
Fix profiling race condition

### DIFF
--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -91,7 +91,10 @@ class SplunkDistro(BaseDistro):
             self.env.setval(OTEL_SERVICE_NAME, _DEFAULT_SERVICE_NAME)
 
     def set_profiling_env(self):
-        if self.env.is_true(SPLUNK_PROFILER_ENABLED, "false"):
+        profiling_active = self.env.is_true(SPLUNK_PROFILER_ENABLED, "false") or self.env.is_true(
+            SPLUNK_SNAPSHOT_PROFILER_ENABLED, "false"
+        )
+        if profiling_active:
             logs_endpt = self.env.getval(SPLUNK_PROFILER_LOGS_ENDPOINT)
             if logs_endpt:
                 self.env.setval(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, logs_endpt)

--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -91,10 +91,9 @@ class SplunkDistro(BaseDistro):
             self.env.setval(OTEL_SERVICE_NAME, _DEFAULT_SERVICE_NAME)
 
     def set_profiling_env(self):
-        profiling_active = self.env.is_true(SPLUNK_PROFILER_ENABLED, "false") or self.env.is_true(
-            SPLUNK_SNAPSHOT_PROFILER_ENABLED, "false"
-        )
-        if profiling_active:
+        profiler_enabled = self.env.is_true(SPLUNK_PROFILER_ENABLED, "false")
+        snapshot_profiler_enabled = self.env.is_true(SPLUNK_SNAPSHOT_PROFILER_ENABLED, "false")
+        if profiler_enabled or snapshot_profiler_enabled:
             logs_endpt = self.env.getval(SPLUNK_PROFILER_LOGS_ENDPOINT)
             if logs_endpt:
                 self.env.setval(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, logs_endpt)

--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -128,12 +128,15 @@ class SplunkDistro(BaseDistro):
             set_global_response_propagator(ServerTimingResponsePropagator())
 
     def set_callgraphs_propagator(self):
+        # Strip any existing CallgraphsPropagator before conditionally adding a fresh one,
+        # so this method is idempotent and the result depends only on the current config.
+        current = get_global_textmap()
+        if isinstance(current, CompositePropagator):
+            propagators = [p for p in current._propagators if not isinstance(p, CallgraphsPropagator)]  # noqa SLF001
+        else:
+            propagators = [current]
+
         if self.env.is_true(SPLUNK_SNAPSHOT_PROFILER_ENABLED, "false"):
-            set_global_textmap(
-                CompositePropagator(
-                    [
-                        get_global_textmap(),
-                        CallgraphsPropagator(self.env.getfloat(SPLUNK_SNAPSHOT_SELECTION_PROBABILITY, 0.01)),
-                    ]
-                )
-            )
+            propagators.append(CallgraphsPropagator(self.env.getfloat(SPLUNK_SNAPSHOT_SELECTION_PROBABILITY, 0.01)))
+
+        set_global_textmap(CompositePropagator(propagators))

--- a/src/splunk_otel/profile.py
+++ b/src/splunk_otel/profile.py
@@ -278,8 +278,8 @@ class _IntervalTimer:
             start_time_seconds = time.monotonic()
 
             if self.pause_at is not None and start_time_seconds >= self.pause_at:
-                # The pause deadline has been reached, sleep until woken again.
-                self.wakeup_event.wait()
+                self.wakeup_event.clear()  # clear event so next line will block
+                self.wakeup_event.wait()  # deadline reached, now wait for event.set() (either via start() or stop())
                 continue
 
             self.target()
@@ -290,13 +290,12 @@ class _IntervalTimer:
     def stop(self):
         self.running = False
         self.pause_at = None
-        self.wakeup_event.set()
-        self.thread.join()
+        self.wakeup_event.set()  # unblock _loop() if waiting, so _loop() can return and thread can exit
+        if self.thread.is_alive():
+            self.thread.join()
 
     def pause_after(self, seconds: float):
-        # The timer will stay running until pause_at has been reached.
         self.pause_at = time.monotonic() + seconds
-        self.wakeup_event.clear()
 
 
 class _StringTable:

--- a/src/splunk_otel/profile.py
+++ b/src/splunk_otel/profile.py
@@ -279,7 +279,7 @@ class _IntervalTimer:
 
             if self.pause_at is not None and start_time_seconds >= self.pause_at:
                 self.wakeup_event.clear()  # clear event so next line will block
-                self.wakeup_event.wait()  # deadline reached, now wait for event.set() (either via start() or stop())
+                self.wakeup_event.wait()  # wait for event.set() (either via start() or stop())
                 continue
 
             self.target()
@@ -290,7 +290,7 @@ class _IntervalTimer:
     def stop(self):
         self.running = False
         self.pause_at = None
-        self.wakeup_event.set()  # unblock _loop() if waiting, so _loop() can return and thread can exit
+        self.wakeup_event.set()  # unblock _loop() if waiting, so it can return and thread can exit
         if self.thread.is_alive():
             self.thread.join()
 

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -87,6 +87,17 @@ def test_profiling_endpt():
     assert "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT" in env_store
 
 
+def test_snapshot_profiling_endpt():
+    # SPLUNK_PROFILER_LOGS_ENDPOINT should also be forwarded when only snapshot
+    # profiling is enabled. Old code only checked SPLUNK_PROFILER_ENABLED.
+    env_store = {
+        "SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true",
+        "SPLUNK_PROFILER_LOGS_ENDPOINT": "my-logs-endpoint",
+    }
+    configure_distro(env_store)
+    assert env_store.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") == "my-logs-endpoint"
+
+
 def test_resource_attributes():
     env_store = {"OTEL_RESOURCE_ATTRIBUTES": "foo=bar"}
     configure_distro(env_store)
@@ -156,15 +167,27 @@ def test_callgraphs_propagator_selection_probability():
     assert callgraphs_propagator.selection_probability == 0.5
 
 
-def test_snapshot_profiling_endpt():
-    # SPLUNK_PROFILER_LOGS_ENDPOINT should also be forwarded when only snapshot
-    # profiling is enabled. Old code only checked SPLUNK_PROFILER_ENABLED.
-    env_store = {
-        "SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true",
-        "SPLUNK_PROFILER_LOGS_ENDPOINT": "my-logs-endpoint",
-    }
+def test_callgraphs_propagator_idempotent():
+    # Configuring twice with snapshot enabled should not accumulate propagators.
+    env_store = {"SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true"}
     configure_distro(env_store)
-    assert env_store.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") == "my-logs-endpoint"
+    configure_distro(env_store)
+
+    textmap = get_global_textmap()
+    propagators = textmap._propagators  # noqa SLF001
+    callgraphs_propagators = [p for p in propagators if isinstance(p, CallgraphsPropagator)]
+    assert len(callgraphs_propagators) == 1
+
+
+def test_callgraphs_propagator_removed_when_disabled():
+    # Enabling then disabling snapshot profiling should leave no CallgraphsPropagator.
+    configure_distro({"SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true"})
+    configure_distro({})
+
+    textmap = get_global_textmap()
+    propagators = textmap._propagators  # noqa SLF001
+    callgraphs_propagators = [p for p in propagators if isinstance(p, CallgraphsPropagator)]
+    assert len(callgraphs_propagators) == 0
 
 
 def configure_distro(env_store):

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -156,6 +156,17 @@ def test_callgraphs_propagator_selection_probability():
     assert callgraphs_propagator.selection_probability == 0.5
 
 
+def test_snapshot_profiling_endpt():
+    # SPLUNK_PROFILER_LOGS_ENDPOINT should also be forwarded when only snapshot
+    # profiling is enabled. Old code only checked SPLUNK_PROFILER_ENABLED.
+    env_store = {
+        "SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true",
+        "SPLUNK_PROFILER_LOGS_ENDPOINT": "my-logs-endpoint",
+    }
+    configure_distro(env_store)
+    assert env_store.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") == "my-logs-endpoint"
+
+
 def configure_distro(env_store):
     sd = SplunkDistro()
     sd.env = Env(env_store)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -21,6 +21,7 @@ from opentelemetry.trace import (
 from splunk_otel import profile_pb2
 from splunk_otel.profile import (
     _get_line,
+    _IntervalTimer,
     _pb_profile_to_str,
     _ProfileScraper,
     _stacktraces_to_cpu_profile,
@@ -147,6 +148,36 @@ def _do_work(time_ms):
         time.sleep(0.01)
 
     return total
+
+
+def test_interval_timer_stop_before_start():
+    # stop() must not raise RuntimeError when the thread was never started.
+    # Old code called thread.join() unconditionally; joining an unstarted
+    # thread raises RuntimeError.
+    timer = _IntervalTimer(100, lambda: None)
+    timer.stop()
+
+
+def test_interval_timer_pause_and_resume():
+    # pause_after() should halt ticking; start() should resume it.
+    ticks = []
+    timer = _IntervalTimer(20, lambda: ticks.append(1))
+    timer.start()
+
+    time.sleep(0.1)
+    assert len(ticks) > 0, "timer should have ticked before pause"
+
+    timer.pause_after(0)
+    time.sleep(0.2)  # enough for the timer to reach pause_at and block
+    count_at_pause = len(ticks)
+    time.sleep(0.1)  # confirm no new ticks while paused
+    assert len(ticks) == count_at_pause, "timer should not tick while paused"
+
+    timer.start()
+    time.sleep(0.1)  # let it resume
+    assert len(ticks) > count_at_pause, "timer should tick again after start()"
+
+    timer.stop()
 
 
 class _FakeLogger(Logger):


### PR DESCRIPTION
Fix a race condition where snapshot profiling could stop emitting data. When a span ended, `pause_after()` could clear the wakeup event after `start()` had already set it, so the loop thread would block indefinitely on `wait()`. Now we just clear the event inline, right before the wait.

Also set the logs endpoint when snapshot profiler is enabled.