### PR TITLE
Upgrade protobuf to 6.33.5 (CVE-2026-0994)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Upgrade `protobuf` minimum version to 6.33.5 to address CVE-2026-0994
+
 ## 2.10.0 - 2026-03-31
 - Upgrade Otel dependencies to [1.40.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.40.0) / [0.61b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.61b0)
 - Add `opentelemetry-instrumentation-logging` as a direct dependency; the logging handler has migrated from the SDK to contrib and is now explicitly instrumented by the distro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "opentelemetry-instrumentation-logging==0.61b0",
   "opentelemetry-instrumentation-system-metrics==0.61b0",
   "opentelemetry-semantic-conventions==0.61b0",
-  "protobuf>=6.31.1", # not our direct dep, prevents installing vulnerable proto versions (CVE‑2025‑4565)
+  "protobuf>=6.33.5", # not our direct dep, prevents installing vulnerable proto versions (CVE‑2025‑4565, CVE-2026-0994)
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Upgrade `protobuf` minimum version from 6.31.1 to 6.33.5 to remediate CVE-2026-0994

## Details

CVE-2026-0994 is a HIGH severity DoS vulnerability in `google.protobuf.json_format.ParseDict()` where the `max_recursion_depth` limit can be bypassed when parsing nested `google.protobuf.Any` messages, exhausting Python's recursion stack.

Closes #719