### PR TITLE
Bump version to 2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 2.10.1 - 2026-04-23
+- Restrict `wrapt` to `<2.0.0` to fix `TypeError: 'TracedCursorProxy' object is not iterable` when using DB instrumentation on fresh installs ([upstream issue](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4462))
+
 ## 2.10.0 - 2026-04-21
 - Upgrade Otel dependencies to [1.41.0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.41.0) / [0.62b0](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.62b0)
 - Upgrade `protobuf` minimum version to 6.33.5 to address CVE-2026-0994

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@ How to release a new version of the `splunk-opentelemetry` project:
         - `"opentelemetry-instrumentation==0.57b0"`
 3) Bump our version in __about__.py
 4) Update additional version string locations
-    - `ott_lib.py` # this file is used as a library for integration tests
+    - `tests/integration/lib.py` # this file is used as a library for integration tests
     - `docker/requirements.txt` # this file is used to build the docker init image for the operator
     - `docker/example-instrumentation.yaml`  # this file is just an example but would be nice to show the latest version
 5) Add a new entry in CHANGELOG.md

--- a/docker/example-instrumentation.yaml
+++ b/docker/example-instrumentation.yaml
@@ -11,4 +11,4 @@ spec:
     env:
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
         value: http/protobuf
-    image: "splunk-otel-instrumentation-python:v2.10.0"
+    image: "splunk-otel-instrumentation-python:v2.10.1"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,4 @@
-splunk-opentelemetry==2.10.0
+splunk-opentelemetry==2.10.1
 opentelemetry-instrumentation-aio-pika==0.62b0
 opentelemetry-instrumentation-aiohttp-client==0.62b0
 opentelemetry-instrumentation-aiohttp-server==0.62b0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "opentelemetry-instrumentation-system-metrics==0.62b0",
   "opentelemetry-semantic-conventions==0.62b0",
   "protobuf>=6.33.5", # not our direct dep, prevents installing vulnerable proto versions (CVE‑2025‑4565, CVE-2026-0994)
+  "wrapt>=1.0.0,<2.0.0", # wrapt 2 breaks TracedCursorProxy iteration in opentelemetry-instrumentation-dbapi 0.62b0
 ]
 
 [project.urls]

--- a/src/splunk_otel/__about__.py
+++ b/src/splunk_otel/__about__.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"

--- a/tests/integration/dbapi_cursor_iter.py
+++ b/tests/integration/dbapi_cursor_iter.py
@@ -1,0 +1,38 @@
+from lib import project_path
+
+if __name__ == "__main__":
+    import sqlite3
+
+    from opentelemetry.instrumentation.dbapi import trace_integration
+
+    trace_integration(sqlite3, "connect", "sqlite")
+
+    conn = sqlite3.connect(":memory:")
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE t (x INTEGER)")
+    cursor.execute("INSERT INTO t VALUES (1)")
+    cursor.execute("INSERT INTO t VALUES (2)")
+    cursor.execute("SELECT * FROM t")
+
+    rows = list(cursor)
+    assert rows == [(1,), (2,)], f"Expected [(1,), (2,)], got {rows}"
+
+
+class DbapiCursorIterOtelTest:
+    def requirements(self):
+        return (project_path(), "opentelemetry-instrumentation-dbapi")
+
+    def environment_variables(self):
+        return {
+            "OTEL_SERVICE_NAME": "dbapi-cursor-iter-test",
+            "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "system_metrics",
+        }
+
+    def wrapper_command(self):
+        return ""
+
+    def on_start(self):
+        return None
+
+    def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:
+        assert returncode == 0, f"Script failed with returncode {returncode}.\nstdout: {stdout}\nstderr: {stderr}"


### PR DESCRIPTION
Bump version to 2.10.1

Restricts wrapt to <2.0.0 to fix TypeError when iterating DB cursors with
opentelemetry-instrumentation-dbapi. Adds integration test to cover the case.