### PR TITLE
Update dependabot.yml to ignore upstream otel deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,5 @@ updates:
       - "Skip Changelog"
       - "dependencies"
     ignore:
-      - dependency-name: "opentelemetry-api"
-      - dependency-name: "opentelemetry-sdk"
-      - dependency-name: "opentelemetry-propagator-b3"
-      - dependency-name: "opentelemetry-exporter-otlp-proto-grpc"
-      - dependency-name: "opentelemetry-exporter-otlp-proto-http"
-      - dependency-name: "opentelemetry-instrumentation"
-      - dependency-name: "opentelemetry-instrumentation-system-metrics"
-      - dependency-name: "opentelemetry-semantic-conventions"
+      # Upstream OTel dependencies are updated together during releases.
+      - dependency-name: "opentelemetry-*"


### PR DESCRIPTION
Previous spec was too narrow, leading to dependabot creating PRs like [this one](https://github.com/signalfx/splunk-otel-python/pull/735) for opentelemetry-instrumentation-aiohttp-client.