### PR TITLE
ci: pin signing service include to immutable ref

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,9 @@ default:
 
 include:
   - project: core-ee/signing/api-integration
-    ref: develop
+    # Keep this pinned to an immutable commit. To update, choose a reviewed commit
+    # from core-ee/signing/api-integration and validate this CI config in GitLab.
+    ref: addd76a1d97a8b19db80f40fe4f7830d2374303d
     file: /templates/.sign-client.yml
 
 stages:


### PR DESCRIPTION
Pin the internal GitLab signing service include to a commit SHA instead of the mutable develop branch to prevent release pipeline changes when that branch moves.