### PR TITLE
ci: restrict Docker publish to protected release tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,10 @@ include:
     ref: develop
     file: /templates/.sign-client.yml
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+
 stages:
   - build
   - sign
@@ -57,8 +61,7 @@ deploy-job:
 publish-docker-image:
   stage: post-release
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-alpha)?.*/'
-    - when: manual  # allow manual triggering (in which case CI_COMMIT_TAG must be set via the UI)
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-alpha)?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
   variables:
     SIGNING_SERVICE_ADDR: "https://signing.prod.svc.splunk8s.io"
   id_tokens:

--- a/docker/publish-docker-image.sh
+++ b/docker/publish-docker-image.sh
@@ -4,6 +4,27 @@ set -e
 cd docker
 
 release_tag="$1" # e.g. v1.2.3
+
+if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-alpha)?$ ]]; then
+  echo "ERROR: release tag must match v<major>.<minor>.<patch>[-alpha]"
+  exit 1
+fi
+
+if [ -z "${CI_COMMIT_TAG:-}" ]; then
+  echo "ERROR: CI_COMMIT_TAG is required"
+  exit 1
+fi
+
+if [ "$CI_COMMIT_TAG" != "$release_tag" ]; then
+  echo "ERROR: release tag argument does not match CI_COMMIT_TAG"
+  exit 1
+fi
+
+if [ "${CI_COMMIT_REF_PROTECTED:-}" != "true" ]; then
+  echo "ERROR: publishing is only allowed from protected refs"
+  exit 1
+fi
+
 major_version=$(echo $release_tag | cut -d '.' -f1) # e.g. "v1"
 repo="quay.io/signalfx/splunk-otel-instrumentation-python"
 


### PR DESCRIPTION
Remove the manual Docker publish option and create the Docker publish job only for protected release tags. Add checks to the publish script for tags that don't conform.