### PR TITLE
Add Docker init image generation for distro + secureapp

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,8 @@ deploy-job:
       when: manual
       allow_failure: false
 
+# The publish script builds and pushes both the standard image and the
+# SecureApp image variant from the same release tag.
 publish-docker-image:
   stage: post-release
   rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add a SecureApp variant of the Python auto-instrumentation Docker image
 - Add a `secureapp` extra for installing the Cisco SecureApp Python agent and document collector routing for SecureApp dependency logs
 - Respect `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=logging` when configuring logging instrumentation from the distro
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ package dependencies through OpenTelemetry logs.
 SecureApp dependency logs use the `secureapp` instrumentation scope. Collector
 deployments must route those logs to the SecureApp event ingest endpoint
 (`/v3/event`) and add the SecureApp instrumentation header on the outbound
-exporter. See
+exporter. See [docs/secureapp.md](docs/secureapp.md) for setup details and
 [docs/examples/secureapp-collector-config.yaml](docs/examples/secureapp-collector-config.yaml)
-for an example.
+for a collector example.
 
 
 # License

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,10 +33,11 @@ How to release a new version of the `splunk-opentelemetry` project:
     - wait for the build and checksum signing jobs to complete successfully
     - run the manual deploy job to publish the package to PyPI
     - confirm the Docker image publish job completes successfully
-13) Smoke test the published PyPI package and Docker image:
+13) Smoke test the published PyPI package and Docker images:
     ```
     SPLUNK_ACCESS_TOKEN=<token> ./tests/smoke/smoke-test-package.sh --pypi
     SPLUNK_ACCESS_TOKEN=<token> ./tests/smoke/smoke-test-docker-image.sh
+    SPLUNK_ACCESS_TOKEN=<token> ./tests/smoke/smoke-test-docker-image.sh --secureapp
     ```
 14) Navigate to Pipelines in the GitLab repo, click the download button for the signing job that just ran,
     and select the 'checksum-signing-job' artifact

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,23 @@
+# Builds both the standard and SecureApp Python auto-instrumentation images.
+# Pass REQUIREMENTS_FILE=requirements-secureapp.txt for the SecureApp variant.
 FROM python:3.11 AS build
 
 WORKDIR /operator-build
 
-ADD requirements.txt .
+# The release script uses requirements-secureapp.txt for the SecureApp image
+# variant and leaves the default requirements.txt for the standard image.
+ARG REQUIREMENTS_FILE=requirements.txt
+ARG VERIFY_SECUREAPP=false
 
-RUN mkdir workspace && pip install --target workspace -r requirements.txt
+COPY requirements*.txt ./
+
+RUN mkdir workspace && pip install --target workspace -r "$REQUIREMENTS_FILE"
+
+# Fail the SecureApp image build early if the selected requirements file did not
+# install the SecureApp extension into /autoinstrumentation.
+RUN if [ "$VERIFY_SECUREAPP" = "true" ]; then \
+      PYTHONPATH=workspace python -c "import importlib.metadata; import splunk_secureapp_opentelemetry_extension; print('secureapp-python-agent', importlib.metadata.version('secureapp-python-agent'))"; \
+    fi
 
 FROM busybox
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,18 @@ This directory contains a Dockerfile and an `example-instrumentation.yaml` file 
 Docker init container that can be used to auto-instrumetation your Python app via the kubernetes
 [OTel Operator](https://github.com/open-telemetry/opentelemetry-operator).
 
+Release publishing creates two Python auto-instrumentation images:
+
+- `quay.io/signalfx/splunk-otel-instrumentation-python:<tag>`
+- `quay.io/signalfx/splunk-otel-instrumentation-python:<tag>-secureapp`
+
+Use the `<tag>-secureapp` image when the init container should also include the
+Cisco SecureApp Python agent. The SecureApp image is intended for Python
+application containers running Python 3.10 or later. SecureApp dependency logs
+require collector routing to the SecureApp event endpoint; see
+[`docs/secureapp.md`](../docs/secureapp.md) and
+[`docs/examples/secureapp-collector-config.yaml`](../docs/examples/secureapp-collector-config.yaml).
+
 # Installation
 
 Install [cert manager](https://cert-manager.io/docs/installation/) into your k8s cluster unless already installed.
@@ -63,6 +75,25 @@ spec:
         value: http/protobuf
     image: "splunk-otel-python-init:v2.0.0"
 
+```
+
+For SecureApp, use the SecureApp image variant:
+
+```yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: splunk-otel-python-secureapp
+spec:
+  exporter:
+    endpoint: http://localhost:4318
+  sampler:
+    type: always_on
+  python:
+    env:
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: http/protobuf
+    image: "quay.io/signalfx/splunk-otel-instrumentation-python:vX.Y.Z-secureapp"
 ```
 
 Create an application image and run it via something like this Deployment. Note the annotations, indicating that

--- a/docker/publish-docker-image.sh
+++ b/docker/publish-docker-image.sh
@@ -27,6 +27,8 @@ fi
 
 major_version=$(echo $release_tag | cut -d '.' -f1) # e.g. "v1"
 repo="quay.io/signalfx/splunk-otel-instrumentation-python"
+image_name="splunk-otel-instrumentation-python"
+secureapp_image_name="splunk-otel-instrumentation-python-secureapp"
 
 check_package_available() {
   package_name="splunk-opentelemetry"
@@ -52,10 +54,21 @@ check_package_available() {
 
 build_docker_image() {
   echo ">>> Building the operator docker image ..."
-  docker build -t splunk-otel-instrumentation-python .
-  docker tag splunk-otel-instrumentation-python ${repo}:latest
-  docker tag splunk-otel-instrumentation-python ${repo}:${major_version}
-  docker tag splunk-otel-instrumentation-python ${repo}:${release_tag}
+  docker build \
+    --build-arg REQUIREMENTS_FILE=requirements.txt \
+    -t "${image_name}" .
+  docker tag "${image_name}" "${repo}:latest"
+  docker tag "${image_name}" "${repo}:${major_version}"
+  docker tag "${image_name}" "${repo}:${release_tag}"
+
+  echo ">>> Building the SecureApp operator docker image ..."
+  docker build \
+    --build-arg REQUIREMENTS_FILE=requirements-secureapp.txt \
+    --build-arg VERIFY_SECUREAPP=true \
+    -t "${secureapp_image_name}" .
+  docker tag "${secureapp_image_name}" "${repo}:latest-secureapp"
+  docker tag "${secureapp_image_name}" "${repo}:${major_version}-secureapp"
+  docker tag "${secureapp_image_name}" "${repo}:${release_tag}-secureapp"
 }
 
 login_to_quay_io() {
@@ -65,9 +78,14 @@ login_to_quay_io() {
 
 publish_docker_image() {
   echo ">>> Publishing the operator docker image ..."
-  docker push ${repo}:latest
-  docker push ${repo}:${major_version}
-  docker push ${repo}:${release_tag}
+  docker push "${repo}:latest"
+  docker push "${repo}:${major_version}"
+  docker push "${repo}:${release_tag}"
+
+  echo ">>> Publishing the SecureApp operator docker image ..."
+  docker push "${repo}:latest-secureapp"
+  docker push "${repo}:${major_version}-secureapp"
+  docker push "${repo}:${release_tag}-secureapp"
 }
 
 check_package_available

--- a/docker/requirements-secureapp.txt
+++ b/docker/requirements-secureapp.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+# Keep this aligned with pyproject.toml's secureapp extra.
+secureapp-python-agent>=26.6.0

--- a/docs/examples/secureapp-collector-config.yaml
+++ b/docs/examples/secureapp-collector-config.yaml
@@ -1,8 +1,8 @@
 # Example Splunk OpenTelemetry Collector configuration for SecureApp logs.
 #
-# Applications send standard OTLP telemetry to the collector. The collector
-# routes only SecureApp dependency logs to the SecureApp event endpoint and adds
-# the backend-specific SecureApp header on that outbound exporter.
+# In this setup, applications send standard OTLP telemetry to the collector. The
+# collector routes only SecureApp dependency logs to the SecureApp event endpoint
+# and adds the backend-specific SecureApp header on that outbound exporter.
 #
 # Required environment variables:
 #   SPLUNK_ACCESS_TOKEN

--- a/docs/secureapp.md
+++ b/docs/secureapp.md
@@ -1,0 +1,123 @@
+# SecureApp
+
+The `secureapp` extra installs the Cisco SecureApp Python agent alongside the
+Splunk OpenTelemetry Python distribution:
+
+```bash
+pip install "splunk-opentelemetry[secureapp]"
+```
+
+For Kubernetes operator auto-instrumentation, use the SecureApp Docker image
+variant:
+
+```text
+quay.io/signalfx/splunk-otel-instrumentation-python:<tag>-secureapp
+```
+
+The SecureApp image is intended for Python application containers running Python
+3.10 or later. The auto-instrumentation image contains native Python
+dependencies, so the application container platform must match the image
+platform.
+
+## What SecureApp Sends
+
+SecureApp reports runtime Python package dependencies through OpenTelemetry
+logs. The dependency report records have:
+
+- instrumentation scope: `secureapp`
+- `event.name`: `com.cisco.secureapp.report.v1`
+
+The report is about loaded runtime libraries. You do not need to install a known
+vulnerable library to send a dependency report. If none of the reported
+libraries match backend vulnerability data, the backend can show libraries with
+zero vulnerabilities.
+
+By default, SecureApp waits 60 seconds before the first dependency scan. For
+smoke tests or short-lived apps, reduce the delay and log batch schedule:
+
+```bash
+export SPLUNK_SECUREAPP_DEPENDENCY_INITIAL_DELAY=1
+export OTEL_BLRP_SCHEDULE_DELAY=500
+```
+
+## Collector Routing
+
+Direct ingest is fine for normal Splunk OpenTelemetry traces and metrics. For
+SecureApp dependency library ingestion, use a Splunk OpenTelemetry Collector so
+it can split SecureApp dependency logs from normal logs. The collector must
+route only SecureApp dependency logs to the SecureApp event endpoint:
+
+```yaml
+connectors:
+  routing/logs:
+    default_pipelines: [logs/default]
+    table:
+      - context: log
+        condition: instrumentation_scope.name == "secureapp"
+        pipelines: [logs/secureapp]
+```
+
+The SecureApp pipeline exports to `/v3/event` and adds the SecureApp-specific
+header:
+
+```yaml
+exporters:
+  otlphttp/secureapp:
+    logs_endpoint: https://ingest.${SPLUNK_REALM}.signalfx.com/v3/event
+    headers:
+      X-SF-TOKEN: ${SPLUNK_ACCESS_TOKEN}
+      X-Splunk-Instrumentation-Library: secureapp
+```
+
+Do not send general application logs to `/v3/event`. Keep normal logs on their
+regular logs pipeline and route only `instrumentation_scope.name == "secureapp"`
+to the SecureApp pipeline. See
+[examples/secureapp-collector-config.yaml](examples/secureapp-collector-config.yaml)
+for a complete collector example.
+
+## Why The Header Matters
+
+`X-Splunk-Instrumentation-Library: secureapp` tells the ingest endpoint that the
+OTLP log payload contains SecureApp event data. Without that header, the backend
+can recognize the service but not process SecureApp dependency libraries.
+
+The header should be attached only on the outbound exporter for the SecureApp
+pipeline. Adding it to all logs is not equivalent, because normal application
+logs should not be sent to the SecureApp event endpoint.
+
+## Direct Ingest
+
+`SPLUNK_REALM` configures the Splunk distro for direct trace and metric ingest,
+but it does not by itself configure SecureApp dependency logs for `/v3/event`.
+
+Direct SecureApp log ingest can only work if the application log exporter sends
+to `/v3/event` and includes both required headers. That is not the recommended
+general setup, because a single application log exporter cannot split SecureApp
+logs from normal application logs. Use collector routing when the application
+emits any non-SecureApp logs.
+
+## Docker Smoke Test
+
+`tests/smoke/smoke-test-docker-image.sh --secureapp` verifies that the published
+SecureApp image variant can populate `/autoinstrumentation`, import
+`secureapp-python-agent`, and send normal traces directly to Splunk Observability
+Cloud.
+
+That smoke test does not validate SecureApp library ingestion. Library ingestion
+requires the collector route to `/v3/event` with
+`X-Splunk-Instrumentation-Library: secureapp`.
+
+## Troubleshooting
+
+If the service appears in Splunk Observability Cloud but shows no libraries:
+
+- Confirm the collector has a route for `instrumentation_scope.name == "secureapp"`.
+- Confirm the SecureApp exporter uses `/v3/event`.
+- Confirm the SecureApp exporter sets `X-Splunk-Instrumentation-Library: secureapp`.
+- Confirm the SecureApp export path authenticates with an access token, either
+  by setting `X-SF-TOKEN` on the exporter or by using a collector auth mechanism
+  that adds it.
+- Let the app run long enough for the dependency scan, or set
+  `SPLUNK_SECUREAPP_DEPENDENCY_INITIAL_DELAY=1` for testing.
+- Confirm the app container platform matches the auto-instrumentation image
+  platform when using the Docker image.

--- a/tests/smoke/smoke-test-docker-image.sh
+++ b/tests/smoke/smoke-test-docker-image.sh
@@ -12,14 +12,23 @@ set -euo pipefail
 #   SPLUNK_ACCESS_TOKEN=<token> ./tests/smoke/smoke-test-docker-image.sh
 #   SPLUNK_ACCESS_TOKEN=<token> SPLUNK_REALM=eu0 ./tests/smoke/smoke-test-docker-image.sh
 #   SPLUNK_ACCESS_TOKEN=<token> ./tests/smoke/smoke-test-docker-image.sh --image <image:tag>
+#   SPLUNK_ACCESS_TOKEN=<token> ./tests/smoke/smoke-test-docker-image.sh --secureapp
+#
+# The --secureapp mode verifies the SecureApp image variant can populate
+# /autoinstrumentation, import secureapp-python-agent, and send normal traces
+# directly to Splunk O11y. It does not validate SecureApp dependency library
+# ingestion, which requires collector routing to the SecureApp event endpoint.
 
 : "${SPLUNK_ACCESS_TOKEN:?must be set}"
 
 DEFAULT_IMAGE="quay.io/signalfx/splunk-otel-instrumentation-python:latest"
+SECUREAPP_IMAGE="quay.io/signalfx/splunk-otel-instrumentation-python:latest-secureapp"
 IMAGE="${DEFAULT_IMAGE}"
+VERIFY_SECUREAPP=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --secureapp) VERIFY_SECUREAPP=true; IMAGE="${SECUREAPP_IMAGE}"; shift ;;
         --image=*) IMAGE="${1#--image=}"; shift ;;
         --image)   IMAGE="$2"; shift 2 ;;
         *) shift ;;
@@ -49,6 +58,10 @@ docker run --rm --platform linux/amd64 \
 
 echo ""
 echo "==> Sending spans to Splunk O11y (realm=${REALM}, service=${SERVICE_NAME})..."
+if [ "${VERIFY_SECUREAPP}" = "true" ]; then
+    echo "==> SecureApp mode verifies image contents/import and normal trace export only."
+    echo "==> It does not validate SecureApp library ingestion; that requires collector routing to /v3/event."
+fi
 docker run --rm --platform linux/amd64 \
     -v "${VOLUME}:/autoinstrumentation:ro" \
     -e PYTHONPATH=/autoinstrumentation \
@@ -56,10 +69,18 @@ docker run --rm --platform linux/amd64 \
     -e SPLUNK_ACCESS_TOKEN="${SPLUNK_ACCESS_TOKEN}" \
     -e SPLUNK_REALM="${REALM}" \
     -e OTEL_BSP_SCHEDULE_DELAY=200 \
+    -e VERIFY_SECUREAPP="${VERIFY_SECUREAPP}" \
     python:3.11-slim \
     /autoinstrumentation/bin/opentelemetry-instrument \
     python -c "
+import importlib.metadata
+import os
 import sqlite3
+
+if os.environ.get('VERIFY_SECUREAPP') == 'true':
+    import splunk_secureapp_opentelemetry_extension
+    print('secureapp-python-agent', importlib.metadata.version('secureapp-python-agent'))
+
 conn = sqlite3.connect(':memory:')
 cur = conn.cursor()
 for i in range(12):


### PR DESCRIPTION
Adds a SecureApp variant of the Python auto-instrumentation Docker image.

The Docker release now builds and publishes both the standard image and a `-secureapp` image that includes `splunk-opentelemetry[secureapp]`.