### PR TITLE
Release/prerelease docker tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ deploy-job:
 publish-docker-image:
   stage: post-release
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[1-9][0-9]*)?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
   variables:
     SIGNING_SERVICE_ADDR: "https://signing.prod.svc.splunk8s.io"
   id_tokens:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ deploy-job:
 publish-docker-image:
   stage: post-release
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-alpha)?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
   variables:
     SIGNING_SERVICE_ADDR: "https://signing.prod.svc.splunk8s.io"
   id_tokens:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ deploy-job:
 publish-docker-image:
   stage: post-release
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[1-9][0-9]*)?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$/ && $CI_COMMIT_REF_PROTECTED == "true"'
   variables:
     SIGNING_SERVICE_ADDR: "https://signing.prod.svc.splunk8s.io"
   id_tokens:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,39 @@
 
 How to release a new version of the `splunk-opentelemetry` project:
 
+## Version and tag formats
+
+Stable releases use the same version number everywhere except that Git tags and
+Docker image tags include a leading `v`:
+
+- Git tag / Docker tag: `vX.Y.Z` (for example, `v3.4.5`)
+- PyPI package version: `X.Y.Z` (for example, `3.4.5`)
+
+Prereleases use SemVer-style Git and Docker tags, but PyPI package versions must
+use the PEP 440 form:
+
+| Release phase | Git tag / Docker tag | PyPI package version |
+| --- | --- | --- |
+| Alpha | `vX.Y.Z-alpha.N` | `X.Y.ZaN` |
+| Beta | `vX.Y.Z-beta.N` | `X.Y.ZbN` |
+| Release candidate | `vX.Y.Z-rc.N` | `X.Y.ZrcN` |
+
+For example, `v3.4.5-rc.1` maps to the PyPI package version `3.4.5rc1`.
+
+Before publishing Docker images, the release script verifies that these package
+version sources all match the derived PyPI version:
+
+- `src/splunk_otel/__about__.py`
+- `docker/requirements.txt`
+- the published `splunk-opentelemetry` package on PyPI
+
+Prerelease Docker images are published only under their exact prerelease tags.
+They do not update `latest`, `vX`, `latest-secureapp`, or `vX-secureapp`.
+
+## Stable release process
+
+Use this process for stable releases such as `v3.4.5`:
+
 1) Create a new branch from `main`
 2) Bump dependency versions in pyproject.toml
     - update otel dependencies to the latest versions, e.g.:
@@ -47,3 +80,22 @@ How to release a new version of the `splunk-opentelemetry` project:
     - set the title to that tag name (e.g. `v2.7.0`)
     - unpack the tarball from step 14 and drag its contents onto the attachments section of the New Release page
     - Leave the defaults selected and click Publish
+
+## Prerelease Docker image process
+
+Use this process when publishing prerelease Docker images such as
+`v3.4.5-rc.1`:
+
+1) Create a branch from `main`
+2) Set `src/splunk_otel/__about__.py` to the PEP 440 package version
+    - for example, use `3.4.5rc1` for Git tag `v3.4.5-rc.1`
+3) Update `docker/requirements.txt` to pin the same package version
+    - for example, `splunk-opentelemetry==3.4.5rc1`
+4) Update other release references if needed, such as `CHANGELOG.md`,
+   `tests/integration/lib.py`, or `docker/example-instrumentation.yaml`
+5) Publish the prerelease package to PyPI
+6) Create a protected GitLab tag using the matching prerelease tag format
+    - allowed formats are `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, and `vX.Y.Z-rc.N`
+7) Confirm the Docker image publish job completes successfully
+8) Smoke test the published Docker images by overriding the image tag as needed
+   for the prerelease image under test

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,8 @@ use the PEP 440 form:
 | Release candidate | `vX.Y.Z-rc.N` | `X.Y.ZrcN` |
 
 For example, `v3.4.5-rc.1` maps to the PyPI package version `3.4.5rc1`.
+Prerelease number `N` may be `0` or a positive integer, but must not include
+leading zeroes.
 
 Before publishing Docker images, the release script verifies that these package
 version sources all match the derived PyPI version:

--- a/docker/publish-docker-image.sh
+++ b/docker/publish-docker-image.sh
@@ -3,13 +3,24 @@ set -e
 
 cd docker
 
-release_tag="$1" # e.g. v1.2.3
+release_tag="$1" # e.g. v1.2.3 or v1.2.3-rc.1
 
-stable_release_regex='^v[0-9]+\.[0-9]+\.[0-9]+$'
-prerelease_regex='^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*$'
+stable_release_regex='^v([0-9]+\.[0-9]+\.[0-9]+)$'
+prerelease_regex='^v([0-9]+\.[0-9]+\.[0-9]+)-(alpha|beta|rc)\.([1-9][0-9]*)$'
 
-if [[ ! "$release_tag" =~ $stable_release_regex && ! "$release_tag" =~ $prerelease_regex ]]; then
-  echo "ERROR: release tag must match v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-<prerelease>"
+if [[ "$release_tag" =~ $stable_release_regex ]]; then
+  package_version="${BASH_REMATCH[1]}"
+elif [[ "$release_tag" =~ $prerelease_regex ]]; then
+  base_version="${BASH_REMATCH[1]}"
+  prerelease_phase="${BASH_REMATCH[2]}"
+  prerelease_number="${BASH_REMATCH[3]}"
+  case "$prerelease_phase" in
+    alpha) package_version="${base_version}a${prerelease_number}" ;;
+    beta) package_version="${base_version}b${prerelease_number}" ;;
+    rc) package_version="${base_version}rc${prerelease_number}" ;;
+  esac
+else
+  echo "ERROR: release tag must match v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-(alpha|beta|rc).<number>"
   exit 1
 fi
 
@@ -42,11 +53,11 @@ check_package_available() {
   max_attempts=10
   sleep_seconds=10
 
-  echo "Waiting for $package_name==$release_tag to be available on PyPI..."
+  echo "Waiting for $package_name==$package_version to be available on PyPI..."
 
   for i in $(seq 1 $max_attempts); do
-      if curl --silent --fail "https://pypi.org/pypi/$package_name/$release_tag/json" > /dev/null; then
-          echo "Package $package_name==$release_tag is available on PyPI."
+      if curl --silent --fail "https://pypi.org/pypi/$package_name/$package_version/json" > /dev/null; then
+          echo "Package $package_name==$package_version is available on PyPI."
           break
       fi
       echo "Attempt $i: Package not yet available. Retrying in $sleep_seconds seconds..."
@@ -54,8 +65,17 @@ check_package_available() {
   done
 
   if [ "$i" -eq "$max_attempts" ]; then
-      echo "ERROR: Package $package_name==$release_tag was not found on PyPI after $max_attempts attempts."
+      echo "ERROR: Package $package_name==$package_version was not found on PyPI after $max_attempts attempts."
       exit 1
+  fi
+}
+
+check_requirements_pin() {
+  expected_requirement="splunk-opentelemetry==${package_version}"
+
+  if ! grep -qxF "$expected_requirement" requirements.txt; then
+    echo "ERROR: requirements.txt must contain $expected_requirement"
+    exit 1
   fi
 }
 
@@ -103,6 +123,7 @@ publish_docker_image() {
   docker push "${repo}:${release_tag}-secureapp"
 }
 
+check_requirements_pin
 check_package_available
 build_docker_image
 login_to_quay_io

--- a/docker/publish-docker-image.sh
+++ b/docker/publish-docker-image.sh
@@ -5,10 +5,17 @@ cd docker
 
 release_tag="$1" # e.g. v1.2.3
 
-if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-alpha)?$ ]]; then
-  echo "ERROR: release tag must match v<major>.<minor>.<patch>[-alpha]"
+stable_release_regex='^v[0-9]+\.[0-9]+\.[0-9]+$'
+prerelease_regex='^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*$'
+
+if [[ ! "$release_tag" =~ $stable_release_regex && ! "$release_tag" =~ $prerelease_regex ]]; then
+  echo "ERROR: release tag must match v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-<prerelease>"
   exit 1
 fi
+
+is_stable_release() {
+  [[ "$release_tag" =~ $stable_release_regex ]]
+}
 
 if [ -z "${CI_COMMIT_TAG:-}" ]; then
   echo "ERROR: CI_COMMIT_TAG is required"
@@ -57,8 +64,10 @@ build_docker_image() {
   docker build \
     --build-arg REQUIREMENTS_FILE=requirements.txt \
     -t "${image_name}" .
-  docker tag "${image_name}" "${repo}:latest"
-  docker tag "${image_name}" "${repo}:${major_version}"
+  if is_stable_release; then
+    docker tag "${image_name}" "${repo}:latest"
+    docker tag "${image_name}" "${repo}:${major_version}"
+  fi
   docker tag "${image_name}" "${repo}:${release_tag}"
 
   echo ">>> Building the SecureApp operator docker image ..."
@@ -66,8 +75,10 @@ build_docker_image() {
     --build-arg REQUIREMENTS_FILE=requirements-secureapp.txt \
     --build-arg VERIFY_SECUREAPP=true \
     -t "${secureapp_image_name}" .
-  docker tag "${secureapp_image_name}" "${repo}:latest-secureapp"
-  docker tag "${secureapp_image_name}" "${repo}:${major_version}-secureapp"
+  if is_stable_release; then
+    docker tag "${secureapp_image_name}" "${repo}:latest-secureapp"
+    docker tag "${secureapp_image_name}" "${repo}:${major_version}-secureapp"
+  fi
   docker tag "${secureapp_image_name}" "${repo}:${release_tag}-secureapp"
 }
 
@@ -78,13 +89,17 @@ login_to_quay_io() {
 
 publish_docker_image() {
   echo ">>> Publishing the operator docker image ..."
-  docker push "${repo}:latest"
-  docker push "${repo}:${major_version}"
+  if is_stable_release; then
+    docker push "${repo}:latest"
+    docker push "${repo}:${major_version}"
+  fi
   docker push "${repo}:${release_tag}"
 
   echo ">>> Publishing the SecureApp operator docker image ..."
-  docker push "${repo}:latest-secureapp"
-  docker push "${repo}:${major_version}-secureapp"
+  if is_stable_release; then
+    docker push "${repo}:latest-secureapp"
+    docker push "${repo}:${major_version}-secureapp"
+  fi
   docker push "${repo}:${release_tag}-secureapp"
 }
 

--- a/docker/publish-docker-image.sh
+++ b/docker/publish-docker-image.sh
@@ -6,7 +6,7 @@ cd docker
 release_tag="$1" # e.g. v1.2.3 or v1.2.3-rc.1
 
 stable_release_regex='^v([0-9]+\.[0-9]+\.[0-9]+)$'
-prerelease_regex='^v([0-9]+\.[0-9]+\.[0-9]+)-(alpha|beta|rc)\.([1-9][0-9]*)$'
+prerelease_regex='^v([0-9]+\.[0-9]+\.[0-9]+)-(alpha|beta|rc)\.(0|[1-9][0-9]*)$'
 
 if [[ "$release_tag" =~ $stable_release_regex ]]; then
   package_version="${BASH_REMATCH[1]}"

--- a/docker/publish-docker-image.sh
+++ b/docker/publish-docker-image.sh
@@ -70,6 +70,16 @@ check_package_available() {
   fi
 }
 
+check_about_version() {
+  version_file="../src/splunk_otel/__about__.py"
+  expected_version_line="__version__ = \"${package_version}\""
+
+  if ! grep -qxF "$expected_version_line" "$version_file"; then
+    echo "ERROR: $version_file must contain $expected_version_line"
+    exit 1
+  fi
+}
+
 check_requirements_pin() {
   expected_requirement="splunk-opentelemetry==${package_version}"
 
@@ -123,6 +133,7 @@ publish_docker_image() {
   docker push "${repo}:${release_tag}-secureapp"
 }
 
+check_about_version
 check_requirements_pin
 check_package_available
 build_docker_image


### PR DESCRIPTION
Security fix: ensure prerelease Docker images are not published as the default stable image.

Prerelease tags like `v1.2.3-rc.0` can now publish Docker images for testing, but only under their exact prerelease tags. The default tags (`latest`, `vX`, `latest-secureapp`, and `vX-secureapp`) remain reserved for stable releases.