### PR TITLE
Harden CI workflow

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: test-${{ github.head_ref }}
   cancel-in-progress: true
@@ -33,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Hatch
-      run: pip install --upgrade hatch "virtualenv<21"
+      run: pip install --upgrade hatch==1.17.0
 
     - name: Run static analysis
       run: hatch fmt --check


### PR DESCRIPTION
Pin `hatch` to a known-good version (latest) and remove the `virtualenv` lower bound (hatch brings in its own version).