### PR TITLE
Add declarative configuration support

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -45,7 +45,7 @@ jobs:
       run: hatch run cov
 
     - name: Install oteltest
-      run: pip install oteltest
+      run: pip install 'oteltest>=0.49.0'
 
     - name: Run oteltests
       run: oteltest tests/integration/*.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,0 @@
-# Repository Instructions
-
-## Python validation
-
-- Before committing or pushing Python changes, run `hatch fmt --check`. The CI
-  workflow uses Hatch's generated static-analysis configuration for both Ruff
-  linting and formatting.
-- Do not substitute a targeted `hatch run ruff check` command for this check. It
-  can use different rules and does not validate formatting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository Instructions
+
+## Python validation
+
+- Before committing or pushing Python changes, run `hatch fmt --check`. The CI
+  workflow uses Hatch's generated static-analysis configuration for both Ruff
+  linting and formatting.
+- Do not substitute a targeted `hatch run ruff check` command for this check. It
+  can use different rules and does not validate formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add experimental declarative SDK configuration support through `OTEL_CONFIG_FILE`
 
 ## 2.12.1 - 2026-08-04
 - Stop bundling the retired `opentelemetry-instrumentation-elasticsearch` package in the operator Docker images

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Cloud instead, set `SPLUNK_REALM` and `SPLUNK_ACCESS_TOKEN` before starting your
 application. `SPLUNK_REALM` configures direct ingest endpoints for traces and
 metrics.
 
+## Declarative configuration
+
+The distribution includes experimental support for the OpenTelemetry declarative
+configuration file format. Set `OTEL_CONFIG_FILE` to the path of the YAML
+configuration file when you start the instrumented application:
+
+```bash
+OTEL_CONFIG_FILE=/path/to/config.yaml opentelemetry-instrument python app.py
+```
+
+See the [basic declarative configuration example](docs/examples/declarative-config.yaml),
+which exports traces, metrics, and logs to a local Collector at `http://localhost:4317`.
+
+This support configures upstream OpenTelemetry SDK components. The GDI
+`distribution.splunk` configuration block is not supported yet. Configure
+exporters, including their endpoints and authentication headers, in the YAML file.
+OpAMP does not report the declarative file as effective configuration and cannot
+manage it remotely yet.
+
 ## Profiling
 
 The Splunk Distribution of OpenTelemetry Python supports continuous profiling and

--- a/docs/examples/declarative-config.yaml
+++ b/docs/examples/declarative-config.yaml
@@ -1,0 +1,32 @@
+file_format: "1.0"
+
+resource:
+  attributes:
+    - name: service.name
+      value: ${OTEL_SERVICE_NAME:-my-python-service}
+
+tracer_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_grpc:
+            endpoint: http://localhost:4317
+
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          otlp_grpc:
+            endpoint: http://localhost:4317
+
+logger_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_grpc:
+            endpoint: http://localhost:4317
+
+propagator:
+  composite:
+    - tracecontext: {}
+    - baggage: {}

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -6,6 +6,9 @@ settings. Agents connected to Splunk Observability Cloud appear on the Fleet
 Management page.
 
 OpAMP support is provisional. Remote configuration is not supported yet.
+When `OTEL_CONFIG_FILE` is set, OpAMP does not report the declarative file as
+effective configuration. OpAMP continues to report settings derived from
+environment variables.
 
 ## Default connection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "opentelemetry-propagator-b3==1.44.0",
   "opentelemetry-exporter-otlp-proto-grpc==1.44.0",
   "opentelemetry-exporter-otlp-proto-http==1.44.0",
+  "opentelemetry-configuration==0.65b0",
   "opentelemetry-instrumentation==0.65b0",
   "opentelemetry-instrumentation-logging==0.65b0",
   "opentelemetry-instrumentation-system-metrics==0.65b0",
@@ -64,7 +65,7 @@ dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
   "ruff",
-  "oteltest",
+  "oteltest>=0.49.0",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/tests/integration/declarative_config.py
+++ b/tests/integration/declarative_config.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     trace.get_tracer_provider().force_flush()
     metrics.get_meter_provider().force_flush()
     _logs.get_logger_provider().force_flush()
-    print(type(get_global_textmap()).__name__)
+    print(type(get_global_textmap()).__name__)  # noqa: T201
 
 
 class DeclarativeConfigOtelTest:
@@ -35,9 +35,7 @@ class DeclarativeConfigOtelTest:
         return (project_path(),)
 
     def declarative_configuration(self):
-        return Path(
-            project_path(), "docs", "examples", "declarative-config.yaml"
-        ).read_text()
+        return Path(project_path(), "docs", "examples", "declarative-config.yaml").read_text()
 
     def environment_variables(self):
         return {
@@ -63,9 +61,7 @@ class DeclarativeConfigOtelTest:
         assert returncode == 0, stderr
         assert SPAN_NAME in get_span_names(telemetry)
         assert METRIC_NAME in get_metric_names(telemetry)
-        assert any(
-            record.body.string_value == LOG_MESSAGE for record in get_logs(telemetry)
-        )
+        assert any(record.body.string_value == LOG_MESSAGE for record in get_logs(telemetry))
         assert "CompositePropagator" in stdout
 
         attributes = extract_leaves(
@@ -76,9 +72,7 @@ class DeclarativeConfigOtelTest:
             "resource",
             "attributes",
         )
-        assert (
-            get_attribute(attributes, "service.name").value.string_value == SERVICE_NAME
-        )
+        assert get_attribute(attributes, "service.name").value.string_value == SERVICE_NAME
 
     def is_http(self):
         return False

--- a/tests/integration/declarative_config.py
+++ b/tests/integration/declarative_config.py
@@ -1,0 +1,84 @@
+import logging
+from pathlib import Path
+
+from opentelemetry import _logs, metrics, trace
+from opentelemetry.propagate import get_global_textmap
+
+from lib import project_path
+
+LOGGER_NAME = "declarative-test"
+LOG_MESSAGE = "declarative configuration test"
+METRIC_NAME = "declarative.test"
+SERVICE_NAME = "declarative-test"
+SPAN_NAME = "declarative-test-span"
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    tracer = trace.get_tracer("declarative-test")
+    meter = metrics.get_meter("declarative-test")
+    logger = logging.getLogger(LOGGER_NAME)
+
+    with tracer.start_as_current_span(SPAN_NAME):
+        meter.create_counter(METRIC_NAME).add(1)
+        logger.warning(LOG_MESSAGE)
+
+    trace.get_tracer_provider().force_flush()
+    metrics.get_meter_provider().force_flush()
+    _logs.get_logger_provider().force_flush()
+    print(type(get_global_textmap()).__name__)
+
+
+class DeclarativeConfigOtelTest:
+    def requirements(self):
+        return (project_path(),)
+
+    def declarative_configuration(self):
+        return Path(
+            project_path(), "docs", "examples", "declarative-config.yaml"
+        ).read_text()
+
+    def environment_variables(self):
+        return {
+            "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "system_metrics",
+            "OTEL_SERVICE_NAME": SERVICE_NAME,
+        }
+
+    def wrapper_command(self):
+        return "opentelemetry-instrument"
+
+    def on_start(self):
+        return None
+
+    def on_stop(self, telemetry, stdout: str, stderr: str, returncode: int) -> None:
+        from oteltest.telemetry import (
+            extract_leaves,
+            get_attribute,
+            get_logs,
+            get_metric_names,
+            get_span_names,
+        )
+
+        assert returncode == 0, stderr
+        assert SPAN_NAME in get_span_names(telemetry)
+        assert METRIC_NAME in get_metric_names(telemetry)
+        assert any(
+            record.body.string_value == LOG_MESSAGE for record in get_logs(telemetry)
+        )
+        assert "CompositePropagator" in stdout
+
+        attributes = extract_leaves(
+            telemetry,
+            "trace_requests",
+            "pbreq",
+            "resource_spans",
+            "resource",
+            "attributes",
+        )
+        assert (
+            get_attribute(attributes, "service.name").value.string_value == SERVICE_NAME
+        )
+
+    def is_http(self):
+        return False


### PR DESCRIPTION
This is the first of three planned PRs to add declarative configuration support to Splunk Otel Python.

1. Bundle and validate basic upstream declarative configuration. (this PR)
2. Add Splunk integration through the GDI distribution.splunk block, including profiling and distribution behavior.
3. Integrate declarative configuration with OpAMP effective-configuration reporting.
