### PR TITLE
Refactor profiling dependencies

### DIFF
--- a/src/splunk_otel/callgraphs/__init__.py
+++ b/src/splunk_otel/callgraphs/__init__.py
@@ -7,11 +7,16 @@ from splunk_otel.env import (
     SPLUNK_SNAPSHOT_PROFILER_ENABLED,
     SPLUNK_SNAPSHOT_SAMPLING_INTERVAL,
 )
+from splunk_otel.profile import _get_profiling_logger, _mk_resource
 
 
 def _configure_callgraphs_if_enabled(env=None):
     env = env or Env()
     if env.is_true(SPLUNK_SNAPSHOT_PROFILER_ENABLED):
         trace.get_tracer_provider().add_span_processor(
-            CallgraphsSpanProcessor(env.getval(OTEL_SERVICE_NAME), env.getint(SPLUNK_SNAPSHOT_SAMPLING_INTERVAL, 10))
+            CallgraphsSpanProcessor(
+                _mk_resource(env.getval(OTEL_SERVICE_NAME)),
+                _get_profiling_logger(),
+                env.getint(SPLUNK_SNAPSHOT_SAMPLING_INTERVAL, 10),
+            )
         )

--- a/src/splunk_otel/callgraphs/span_processor.py
+++ b/src/splunk_otel/callgraphs/span_processor.py
@@ -11,16 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import threading
+from typing import TYPE_CHECKING, cast
 
 from opentelemetry import baggage, trace
+from opentelemetry._logs import Logger
 from opentelemetry.context import Context
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
 from splunk_otel.profile import ProfilingContext
 from splunk_otel.propagator import _SPLUNK_TRACE_SNAPSHOT_VOLUME
 
-import threading
+if TYPE_CHECKING:
+    from opentelemetry.trace import SpanContext
 
 
 def _should_process_context(context: Context | None) -> bool:
@@ -32,11 +36,20 @@ def _should_process_context(context: Context | None) -> bool:
 
 
 class CallgraphsSpanProcessor(SpanProcessor):
-    def __init__(self, service_name: str, sampling_interval: int | None = 10):
+    def __init__(
+        self,
+        resource: Resource,
+        logger: Logger,
+        sampling_interval: int = 10,
+    ):
         self._span_id_to_trace_id: dict[int, int] = {}
         self._lock = threading.Lock()
         self._profiler = ProfilingContext(
-            service_name, sampling_interval, self._filter_stacktraces, instrumentation_source="snapshot"
+            resource,
+            sampling_interval,
+            logger,
+            self._filter_stacktraces,
+            instrumentation_source="snapshot",
         )
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
@@ -61,7 +74,7 @@ class CallgraphsSpanProcessor(SpanProcessor):
             self._profiler.start()
 
     def on_end(self, span: ReadableSpan) -> None:
-        span_id = span.get_span_context().span_id
+        span_id = cast("SpanContext", span.get_span_context()).span_id
         trace_id = self._span_id_to_trace_id.get(span_id)
 
         if trace_id is None:

--- a/src/splunk_otel/profile.py
+++ b/src/splunk_otel/profile.py
@@ -38,23 +38,20 @@ _SPLUNK_DISTRO_VERSION_ATTR = "splunk.distro.version"
 _SCOPE_VERSION = "0.2.0"
 _SCOPE_NAME = "otel.profiling"
 
-_thread_states = {}
+_thread_states: dict[int, tuple[int, int] | None] = {}
 _context_tracking_started = False
 
 
 class ProfilingContext:
-    _timer = None
-
     def __init__(
         self,
-        service_name: str,
+        resource: Resource,
         interval_millis: int,
+        logger: Logger,
         stacktrace_filter: Callable[[list[dict], dict], list[dict]] | None = None,
         instrumentation_source: Literal["continuous", "snapshot"] | None = "continuous",
     ):
         start_thread_context_tracking()
-        resource = _mk_resource(service_name)
-        logger = get_logger(_SCOPE_NAME, _SCOPE_VERSION)
         scraper = _ProfileScraper(
             resource,
             _thread_states,
@@ -63,7 +60,7 @@ class ProfilingContext:
             stacktrace_filter=stacktrace_filter,
             instrumentation_source=instrumentation_source,
         )
-        self._timer = _IntervalTimer(interval_millis, scraper.tick)
+        self._timer: _IntervalTimer = _IntervalTimer(interval_millis, scraper.tick)
 
     def start(self):
         self._timer.start()
@@ -86,9 +83,17 @@ def start_profiling(env=None):
     interval_millis = env.getint(SPLUNK_PROFILER_CALL_STACK_INTERVAL, _DEFAULT_PROF_CALL_STACK_INTERVAL_MILLIS)
     svcname = env.getval(OTEL_SERVICE_NAME)
 
-    ctx = ProfilingContext(svcname, interval_millis)
+    ctx = ProfilingContext(
+        _mk_resource(svcname),
+        interval_millis,
+        get_logger(_SCOPE_NAME, _SCOPE_VERSION),
+    )
     ctx.start()
     return ctx
+
+
+def _get_profiling_logger() -> Logger:
+    return get_logger(_SCOPE_NAME, _SCOPE_VERSION)
 
 
 def _mk_resource(service_name) -> Resource:

--- a/tests/test_callgraphs_init.py
+++ b/tests/test_callgraphs_init.py
@@ -28,9 +28,11 @@ class TestStartCallgraphsIfEnabled:
 
         mock_trace.get_tracer_provider.return_value.add_span_processor.assert_not_called()
 
+    @patch("splunk_otel.callgraphs._get_profiling_logger")
+    @patch("splunk_otel.callgraphs._mk_resource")
     @patch("splunk_otel.callgraphs.trace")
     @patch("splunk_otel.callgraphs.CallgraphsSpanProcessor")
-    def test_adds_processor_when_enabled(self, mock_processor, mock_trace):
+    def test_adds_processor_when_enabled(self, mock_processor, mock_trace, mk_resource, get_profiling_logger):
         env_store = {
             "SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true",
             "OTEL_SERVICE_NAME": "test-service",
@@ -39,12 +41,18 @@ class TestStartCallgraphsIfEnabled:
 
         _configure_callgraphs_if_enabled(env)
 
-        mock_trace.get_tracer_provider.return_value.add_span_processor.assert_called_once()
-        mock_processor.assert_called_once_with("test-service", 10)
+        mk_resource.assert_called_once_with("test-service")
+        get_profiling_logger.assert_called_once_with()
+        mock_processor.assert_called_once_with(mk_resource.return_value, get_profiling_logger.return_value, 10)
+        mock_trace.get_tracer_provider.return_value.add_span_processor.assert_called_once_with(
+            mock_processor.return_value
+        )
 
+    @patch("splunk_otel.callgraphs._get_profiling_logger")
+    @patch("splunk_otel.callgraphs._mk_resource")
     @patch("splunk_otel.callgraphs.trace")
     @patch("splunk_otel.callgraphs.CallgraphsSpanProcessor")
-    def test_uses_custom_sampling_interval(self, mock_processor, mock_trace):
+    def test_uses_custom_sampling_interval(self, mock_processor, mock_trace, mk_resource, get_profiling_logger):
         env_store = {
             "SPLUNK_SNAPSHOT_PROFILER_ENABLED": "true",
             "OTEL_SERVICE_NAME": "test-service",
@@ -54,4 +62,7 @@ class TestStartCallgraphsIfEnabled:
 
         _configure_callgraphs_if_enabled(env)
 
-        mock_processor.assert_called_once_with("test-service", 50)
+        mock_processor.assert_called_once_with(mk_resource.return_value, get_profiling_logger.return_value, 50)
+        mock_trace.get_tracer_provider.return_value.add_span_processor.assert_called_once_with(
+            mock_processor.return_value
+        )

--- a/tests/test_callgraphs_span_processor.py
+++ b/tests/test_callgraphs_span_processor.py
@@ -16,10 +16,15 @@ from unittest.mock import MagicMock, patch
 
 from opentelemetry import baggage, trace
 from opentelemetry.context import Context
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span
 from opentelemetry.trace import SpanContext
 
 from splunk_otel.callgraphs.span_processor import CallgraphsSpanProcessor, _should_process_context
+
+
+def _processor():
+    return CallgraphsSpanProcessor(Resource({}), MagicMock())
 
 
 class TestShouldProcessContext:
@@ -52,7 +57,7 @@ class TestShouldProcessContext:
 class TestCallgraphsSpanProcessor:
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_start_does_nothing_when_baggage_is_none(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         span = MagicMock(spec=Span)
 
         processor.on_start(span, Context())
@@ -62,7 +67,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_start_does_nothing_when_baggage_is_off(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         span = MagicMock(spec=Span)
         ctx = baggage.set_baggage("splunk.trace.snapshot.volume", "off", Context())
 
@@ -73,7 +78,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_start_does_nothing_when_parent_is_local(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         span = MagicMock(spec=Span)
 
         parent_span = trace.NonRecordingSpan(
@@ -89,7 +94,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_start_activates_profiling_when_baggage_is_highest(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
 
         span = MagicMock(spec=Span)
         span_ctx = SpanContext(trace_id=123, span_id=456, is_remote=False)
@@ -106,7 +111,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_end_removes_span_from_tracking(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         processor._span_id_to_trace_id[456] = 123  # noqa SLF001
 
         span = MagicMock(spec=Span)
@@ -119,7 +124,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_end_pauses_profiler_when_no_active_spans(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         processor._span_id_to_trace_id[456] = 123  # noqa SLF001
 
         span = MagicMock(spec=Span)
@@ -132,7 +137,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_end_does_not_pause_profiler_when_other_spans_active(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         processor._span_id_to_trace_id[456] = 123  # noqa SLF001
         processor._span_id_to_trace_id[789] = 123  # noqa SLF001
 
@@ -146,7 +151,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_on_end_ignores_untracked_spans(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
 
         span = MagicMock(spec=Span)
         span_ctx = SpanContext(trace_id=123, span_id=456, is_remote=False)
@@ -158,7 +163,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_filter_stacktraces_keeps_active_traces(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
         processor._span_id_to_trace_id[456] = 123  # noqa SLF001
 
         stacktraces = [
@@ -178,7 +183,7 @@ class TestCallgraphsSpanProcessor:
 
     @patch("splunk_otel.callgraphs.span_processor.ProfilingContext")
     def test_filter_stacktraces_returns_empty_when_no_active_traces(self, mock_profiling_context):
-        processor = CallgraphsSpanProcessor("test-service")
+        processor = _processor()
 
         stacktraces = [
             {"tid": 1, "frames": []},


### PR DESCRIPTION
This is a behavior-neutral change in preparation for later declarative config changes.

Today, the profiler creates its metadata and otel logger internally from environment-based settings. That makes the profiler difficult to use with other configuration sources.

This change lets the caller pass in those objects. Existing behavior stays the same, but the profiler can later work with settings loaded from a configuration file or received remotely through OpAMP.