### PR TITLE
refactor: move startup functions

### DIFF
--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -16,9 +16,6 @@ import logging
 import re
 
 from opentelemetry.instrumentation.distro import BaseDistro
-from opentelemetry.instrumentation.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
-from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry.instrumentation.propagators import set_global_response_propagator
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_HEADERS,
@@ -40,10 +37,13 @@ from splunk_otel.env import (
     SPLUNK_REALM,
     SPLUNK_SNAPSHOT_PROFILER_ENABLED,
     SPLUNK_SNAPSHOT_SELECTION_PROBABILITY,
-    SPLUNK_TRACE_RESPONSE_HEADER_ENABLED,
     Env,
 )
-from splunk_otel.propagator import CallgraphsPropagator, ServerTimingResponsePropagator
+from splunk_otel.propagator import CallgraphsPropagator
+from splunk_otel.runtime import (
+    configure_logging_instrumentation,
+    configure_server_timing_response_propagation,
+)
 
 _DISTRO_NAME = "splunk-opentelemetry"
 
@@ -52,8 +52,6 @@ Set your service name using the OTEL_SERVICE_NAME environment variable.
 e.g. `OTEL_SERVICE_NAME="<YOUR_SERVICE_NAME_HERE>"`"""
 _DEFAULT_SERVICE_NAME = "unnamed-python-service"
 _X_SF_TOKEN = "x-sf-token"  # noqa S105
-_DISABLED_INSTRUMENTATIONS_WILDCARD = "*"
-_LOGGING_INSTRUMENTATION_NAME = "logging"
 _REALM_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
 
 _pylogger = logging.getLogger(__name__)
@@ -75,9 +73,9 @@ class SplunkDistro(BaseDistro):
         self.set_resource_attributes()
         self.handle_realm()
         self.configure_token_headers()
-        self.set_server_timing_propagator()
         self.set_callgraphs_propagator()
-        self.configure_logging()
+        configure_server_timing_response_propagation(self.env)
+        configure_logging_instrumentation(self.env)
 
     def set_env_defaults(self):
         for key, value in DEFAULTS.items():
@@ -125,10 +123,6 @@ class SplunkDistro(BaseDistro):
         if tok:
             self.env.list_append(OTEL_EXPORTER_OTLP_HEADERS, f"{_X_SF_TOKEN}={tok}")
 
-    def set_server_timing_propagator(self):
-        if self.env.is_true(SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true"):
-            set_global_response_propagator(ServerTimingResponsePropagator())
-
     def set_callgraphs_propagator(self):
         # Strip any existing CallgraphsPropagator before conditionally adding a fresh one,
         # so this method is idempotent and the result depends only on the current config.
@@ -142,25 +136,3 @@ class SplunkDistro(BaseDistro):
             propagators.append(CallgraphsPropagator(self.env.getfloat(SPLUNK_SNAPSHOT_SELECTION_PROBABILITY, 0.01)))
 
         set_global_textmap(CompositePropagator(propagators))
-
-    def configure_logging(self):
-        # Previously, the SDK's LoggingHandler was enabled by setting
-        # OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true (our default). That handler
-        # has been deprecated in the SDK and moved to opentelemetry-instrumentation-logging.
-        # We call instrument() explicitly here to ensure the handler is installed for users
-        # who don't run under `opentelemetry-instrument` (which would auto-discover it via
-        # entry points). This is safe when running under `opentelemetry-instrument` because
-        # LoggingInstrumentor is a singleton and its instrument() call is idempotent.
-        if self.is_instrumentation_disabled(_LOGGING_INSTRUMENTATION_NAME):
-            return
-
-        LoggingInstrumentor().instrument()
-
-    def is_instrumentation_disabled(self, instrumentation_name):
-        disabled_instrumentations_env = self.env.getval(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS)
-        disabled_instrumentations = [name.strip() for name in disabled_instrumentations_env.split(",")]
-
-        return (
-            _DISABLED_INSTRUMENTATIONS_WILDCARD in disabled_instrumentations
-            or instrumentation_name in disabled_instrumentations
-        )

--- a/src/splunk_otel/runtime.py
+++ b/src/splunk_otel/runtime.py
@@ -1,0 +1,57 @@
+#  Copyright Splunk Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Protocol
+
+from opentelemetry.instrumentation.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+from opentelemetry.instrumentation.propagators import set_global_response_propagator
+
+from splunk_otel.env import SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, Env
+from splunk_otel.propagator import ServerTimingResponsePropagator
+
+_DISABLED_INSTRUMENTATIONS_WILDCARD = "*"
+_LOGGING_INSTRUMENTATION_NAME = "logging"
+
+
+class _LoggingInstrumentor(Protocol):
+    def instrument(self) -> None: ...
+
+
+def configure_server_timing_response_propagation(env: Env) -> None:
+    if env.is_true(SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true"):
+        set_global_response_propagator(ServerTimingResponsePropagator())
+
+
+def configure_logging_instrumentation(
+    env: Env,
+    logging_instrumentor: _LoggingInstrumentor | None = None,
+) -> None:
+    # The SDK LoggingHandler is deprecated. Install its replacement explicitly
+    # for callers that do not use opentelemetry-instrument auto-discovery. This
+    # is safe with auto-discovery because LoggingInstrumentor is a singleton and
+    # instrument() is idempotent.
+    if _is_instrumentation_disabled(env, _LOGGING_INSTRUMENTATION_NAME):
+        return
+    instrumentor = logging_instrumentor if logging_instrumentor is not None else LoggingInstrumentor()
+    instrumentor.instrument()
+
+
+def _is_instrumentation_disabled(env: Env, instrumentation_name: str) -> bool:
+    disabled = env.getval(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS)
+    disabled_instrumentations = [name.strip() for name in disabled.split(",")]
+    return (
+        _DISABLED_INSTRUMENTATIONS_WILDCARD in disabled_instrumentations
+        or instrumentation_name in disabled_instrumentations
+    )

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -222,39 +222,6 @@ def test_callgraphs_propagator_removed_when_disabled():
     assert len(callgraphs_propagators) == 0
 
 
-@pytest.mark.parametrize(
-    "disabled_instrumentations",
-    [
-        "logging",
-        "requests,logging,flask",
-        "requests, logging , flask",
-        "*",
-    ],
-)
-def test_logging_instrumentation_respects_disabled_instrumentations(monkeypatch, disabled_instrumentations):
-    instrument_calls = []
-
-    class LoggingInstrumentorStub:
-        def instrument(self):
-            instrument_calls.append(True)
-
-    monkeypatch.setattr("splunk_otel.distro.LoggingInstrumentor", LoggingInstrumentorStub)
-    configure_distro({"OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": disabled_instrumentations})
-    assert instrument_calls == []
-
-
-def test_logging_instrumentation_enabled_when_not_disabled(monkeypatch):
-    instrument_calls = []
-
-    class LoggingInstrumentorStub:
-        def instrument(self):
-            instrument_calls.append(True)
-
-    monkeypatch.setattr("splunk_otel.distro.LoggingInstrumentor", LoggingInstrumentorStub)
-    configure_distro({"OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "requests,flask"})
-    assert instrument_calls == [True]
-
-
 def configure_distro(env_store):
     sd = SplunkDistro()
     sd.env = Env(env_store)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,51 @@
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from splunk_otel.env import Env
+from splunk_otel.runtime import configure_logging_instrumentation
+
+
+class _FakeLoggingInstrumentor:
+    def __init__(self):
+        self.instrument_calls = 0
+
+    def instrument(self) -> None:
+        self.instrument_calls += 1
+
+
+@pytest.mark.parametrize(
+    "disabled_instrumentations",
+    [
+        "logging",
+        "requests,logging,flask",
+        "requests, logging , flask",
+        "*",
+    ],
+)
+def test_logging_instrumentation_respects_disabled_instrumentations(disabled_instrumentations):
+    logging_instrumentor = _configure_logging({"OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": disabled_instrumentations})
+    assert logging_instrumentor.instrument_calls == 0
+
+
+def test_logging_instrumentation_is_enabled_when_not_disabled():
+    logging_instrumentor = _configure_logging({"OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "requests,flask"})
+    assert logging_instrumentor.instrument_calls == 1
+
+
+def _configure_logging(env_store):
+    logging_instrumentor = _FakeLoggingInstrumentor()
+    configure_logging_instrumentation(Env(env_store), logging_instrumentor)
+    return logging_instrumentor


### PR DESCRIPTION
Moves a couple of functions from SplunkDistro so that they can be used by future declarative configuration code.