### PR TITLE
Apply Splunk configuration when OTEL_CONFIG_FILE is set

### DIFF
--- a/src/splunk_otel/configurator.py
+++ b/src/splunk_otel/configurator.py
@@ -12,14 +12,112 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from opentelemetry.sdk._configuration import _OTelSDKConfigurator
+import logging
 
-from splunk_otel.profile import _start_profiling_if_enabled
+from opentelemetry.configuration import load_config_file
+from opentelemetry.configuration._logger_provider import configure_logger_provider
+from opentelemetry.configuration._meter_provider import configure_meter_provider
+from opentelemetry.configuration._propagator import configure_propagator
+from opentelemetry.configuration._resource import create_resource
+from opentelemetry.configuration._tracer_provider import configure_tracer_provider
+from opentelemetry.configuration.instrumentation import configure_instrumentation
+from opentelemetry.configuration.models import OpenTelemetryConfiguration, Resource as ResourceConfig
+from opentelemetry.instrumentation.propagators import set_global_response_propagator
+from opentelemetry.sdk._configuration import _OTelSDKConfigurator
+from opentelemetry.sdk.environment_variables import OTEL_CONFIG_FILE
+from opentelemetry.sdk.resources import Resource
+
+from splunk_otel.__about__ import __version__ as version
 from splunk_otel.callgraphs import _configure_callgraphs_if_enabled
+from splunk_otel.distro import _DEFAULT_SERVICE_NAME, _DISTRO_NAME
+from splunk_otel.env import SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, Env
+from splunk_otel.profile import _start_profiling_if_enabled
+from splunk_otel.propagator import ServerTimingResponsePropagator
+from splunk_otel.runtime import (
+    _SERVER_TIMING_DEFAULT_ENABLED,
+    configure_logging_instrumentation,
+)
+
+_logger = logging.getLogger(__name__)
+
+_DECLARATIVE_SERVICE_NAME_WARNING = """The service.name attribute is not set, which may make your service difficult to identify.
+Set your service name in the resource.attributes section of the OpenTelemetry configuration file."""
 
 
 class SplunkConfigurator(_OTelSDKConfigurator):
     def _configure(self, **kwargs):
-        super()._configure(**kwargs)
-        _start_profiling_if_enabled()
-        _configure_callgraphs_if_enabled()
+        env = Env()
+        config_file = env.getval(OTEL_CONFIG_FILE)
+        if config_file:
+            config = _configure_declarative_sdk(config_file, **kwargs)
+            if config is None:
+                return
+            server_timing_enabled = _declarative_server_timing_enabled(config)
+        else:
+            # use the env var configuration logic from the upstream configurator
+            super()._configure(**kwargs)
+            server_timing_enabled = env.is_true(
+                SPLUNK_TRACE_RESPONSE_HEADER_ENABLED,
+                str(_SERVER_TIMING_DEFAULT_ENABLED),
+            )
+
+        if server_timing_enabled:
+            set_global_response_propagator(ServerTimingResponsePropagator())
+        configure_logging_instrumentation(env)
+
+        # A later change will configure profiling and callgraphs from OTEL_CONFIG_FILE.
+        # For now, start them from environment variables only when no config file is set.
+        if not config_file:
+            _start_profiling_if_enabled()
+            _configure_callgraphs_if_enabled()
+
+
+def _configure_declarative_sdk(config_file: str, **kwargs) -> OpenTelemetryConfiguration | None:
+    if kwargs:
+        _logger.warning(
+            "%s is set; ignoring configurator kwargs: %s",
+            OTEL_CONFIG_FILE,
+            sorted(kwargs),
+        )
+
+    config = load_config_file(config_file)
+    if config.disabled:
+        _logger.warning("Declarative configuration has disabled=true; skipping SDK setup.")
+        return None
+
+    resource = _create_declarative_resource(config.resource)
+    configure_tracer_provider(config.tracer_provider, resource)
+    configure_meter_provider(config.meter_provider, resource)
+    configure_logger_provider(config.logger_provider, resource)
+    configure_propagator(config.propagator)
+    configure_instrumentation(config.instrumentation_development)
+    return config
+
+
+def _declarative_server_timing_enabled(config: OpenTelemetryConfiguration) -> bool:
+    match config.distribution:
+        case {
+            "splunk": {
+                "instrumentations": {
+                    "http": {
+                        "trace_response_header_enabled": bool(enabled),
+                    },
+                },
+            },
+        }:
+            return enabled
+        case _:
+            return _SERVER_TIMING_DEFAULT_ENABLED
+
+
+def _create_declarative_resource(resource_config: ResourceConfig | None) -> Resource:
+    resource = create_resource(resource_config)
+    attributes = {
+        "telemetry.distro.name": _DISTRO_NAME,
+        "telemetry.distro.version": version,
+    }
+    service_name = resource.attributes.get("service.name")
+    if not service_name or str(service_name).startswith("unknown_service"):
+        _logger.warning(_DECLARATIVE_SERVICE_NAME_WARNING)
+        attributes["service.name"] = _DEFAULT_SERVICE_NAME
+    return resource.merge(Resource(attributes))

--- a/src/splunk_otel/distro.py
+++ b/src/splunk_otel/distro.py
@@ -18,6 +18,7 @@ import re
 from opentelemetry.instrumentation.distro import BaseDistro
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.environment_variables import (
+    OTEL_CONFIG_FILE,
     OTEL_EXPORTER_OTLP_HEADERS,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
@@ -40,10 +41,6 @@ from splunk_otel.env import (
     Env,
 )
 from splunk_otel.propagator import CallgraphsPropagator
-from splunk_otel.runtime import (
-    configure_logging_instrumentation,
-    configure_server_timing_response_propagation,
-)
 
 _DISTRO_NAME = "splunk-opentelemetry"
 
@@ -138,6 +135,6 @@ class SplunkDistro(BaseDistro):
 
     def _configure(self, **kwargs):
         env = Env()
+        if env.getval(OTEL_CONFIG_FILE):
+            return
         EnvironmentConfiguration(env).configure()
-        configure_server_timing_response_propagation(env)
-        configure_logging_instrumentation(env)

--- a/src/splunk_otel/runtime.py
+++ b/src/splunk_otel/runtime.py
@@ -16,22 +16,16 @@ from typing import Protocol
 
 from opentelemetry.instrumentation.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry.instrumentation.propagators import set_global_response_propagator
 
-from splunk_otel.env import SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, Env
-from splunk_otel.propagator import ServerTimingResponsePropagator
+from splunk_otel.env import Env
 
 _DISABLED_INSTRUMENTATIONS_WILDCARD = "*"
 _LOGGING_INSTRUMENTATION_NAME = "logging"
+_SERVER_TIMING_DEFAULT_ENABLED = True
 
 
 class _LoggingInstrumentor(Protocol):
     def instrument(self) -> None: ...
-
-
-def configure_server_timing_response_propagation(env: Env) -> None:
-    if env.is_true(SPLUNK_TRACE_RESPONSE_HEADER_ENABLED, "true"):
-        set_global_response_propagator(ServerTimingResponsePropagator())
 
 
 def configure_logging_instrumentation(

--- a/tests/integration/declarative_config.py
+++ b/tests/integration/declarative_config.py
@@ -14,6 +14,8 @@ SPAN_NAME = "declarative-test-span"
 
 
 if __name__ == "__main__":
+    from opentelemetry.instrumentation.propagators import get_global_response_propagator
+
     logging.basicConfig(level=logging.INFO)
 
     tracer = trace.get_tracer("declarative-test")
@@ -28,6 +30,7 @@ if __name__ == "__main__":
     metrics.get_meter_provider().force_flush()
     _logs.get_logger_provider().force_flush()
     print(type(get_global_textmap()).__name__)  # noqa: T201
+    print(f"response-propagator={type(get_global_response_propagator()).__name__}")  # noqa: T201
 
 
 class DeclarativeConfigOtelTest:
@@ -35,12 +38,23 @@ class DeclarativeConfigOtelTest:
         return (project_path(),)
 
     def declarative_configuration(self):
-        return Path(project_path(), "docs", "examples", "declarative-config.yaml").read_text()
+        config = Path(project_path(), "docs", "examples", "declarative-config.yaml").read_text()
+        return (
+            config
+            + """
+distribution:
+  splunk:
+    instrumentations:
+      http:
+        trace_response_header_enabled: false
+"""
+        )
 
     def environment_variables(self):
         return {
             "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "system_metrics",
             "OTEL_SERVICE_NAME": SERVICE_NAME,
+            "SPLUNK_TRACE_RESPONSE_HEADER_ENABLED": "true",
         }
 
     def wrapper_command(self):
@@ -63,6 +77,7 @@ class DeclarativeConfigOtelTest:
         assert METRIC_NAME in get_metric_names(telemetry)
         assert any(record.body.string_value == LOG_MESSAGE for record in get_logs(telemetry))
         assert "CompositePropagator" in stdout
+        assert "response-propagator=NoneType" in stdout
 
         attributes = extract_leaves(
             telemetry,
@@ -73,6 +88,7 @@ class DeclarativeConfigOtelTest:
             "attributes",
         )
         assert get_attribute(attributes, "service.name").value.string_value == SERVICE_NAME
+        assert get_attribute(attributes, "telemetry.distro.name").value.string_value == "splunk-opentelemetry"
 
     def is_http(self):
         return False

--- a/tests/test_configurator.py
+++ b/tests/test_configurator.py
@@ -1,0 +1,89 @@
+# Copyright Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+from opentelemetry.configuration import ConfigurationError
+from opentelemetry.configuration.models import (
+    AttributeNameValue,
+    OpenTelemetryConfiguration,
+    Resource as ResourceConfig,
+)
+
+from splunk_otel.configurator import (
+    _configure_declarative_sdk,
+    _create_declarative_resource,
+    _declarative_server_timing_enabled,
+)
+
+
+def test_disabled_file_skips_sdk_setup(tmp_path, caplog):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text('file_format: "1.0"\ndisabled: true\n')
+
+    with caplog.at_level(logging.WARNING):
+        config = _configure_declarative_sdk(str(config_file))
+
+    assert config is None
+    assert "disabled=true" in caplog.text
+
+
+def test_invalid_file_fails_configuration(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text('file_format: "1.0"\ndisabled: [\n')
+
+    with pytest.raises(ConfigurationError):
+        _configure_declarative_sdk(str(config_file))
+
+
+def test_declarative_resource_adds_distro_metadata_and_service_fallback(caplog):
+    with caplog.at_level(logging.WARNING):
+        resource = _create_declarative_resource(None)
+
+    assert resource.attributes["service.name"] == "unnamed-python-service"
+    assert resource.attributes["telemetry.distro.name"] == "splunk-opentelemetry"
+    assert resource.attributes["telemetry.distro.version"]
+    assert "service.name" in caplog.text
+
+
+def test_declarative_resource_preserves_explicit_service_name(caplog):
+    config = ResourceConfig(attributes=[AttributeNameValue(name="service.name", value="configured-service")])
+
+    with caplog.at_level(logging.WARNING):
+        resource = _create_declarative_resource(config)
+
+    assert resource.attributes["service.name"] == "configured-service"
+    assert not caplog.text
+
+
+def test_declarative_server_timing_is_enabled_by_default():
+    config = OpenTelemetryConfiguration(file_format="1.0")
+
+    assert _declarative_server_timing_enabled(config)
+
+
+def test_declarative_server_timing_reads_splunk_http_configuration():
+    config = OpenTelemetryConfiguration(
+        file_format="1.0",
+        distribution={
+            "splunk": {
+                "instrumentations": {
+                    "http": {"trace_response_header_enabled": False},
+                },
+            },
+        },
+    )
+
+    assert not _declarative_server_timing_enabled(config)

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -14,10 +14,6 @@
 import logging
 
 import pytest
-from opentelemetry.instrumentation.propagators import (
-    get_global_response_propagator,
-    set_global_response_propagator,
-)
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 
@@ -25,7 +21,6 @@ from splunk_otel.__about__ import __version__ as version
 from splunk_otel.distro import EnvironmentConfiguration
 from splunk_otel.env import Env
 from splunk_otel.propagator import CallgraphsPropagator
-from splunk_otel.runtime import configure_server_timing_response_propagation
 
 
 def test_distro_env():
@@ -57,27 +52,6 @@ def test_access_token_whitespace():
     env_store = {"SPLUNK_ACCESS_TOKEN": " "}
     configure_environment(env_store)
     assert "OTEL_EXPORTER_OTLP_HEADERS" not in env_store
-
-
-def test_server_timing_resp_prop_default():
-    set_global_response_propagator(None)
-    env_store = {}
-    configure_server_timing_response_propagation(Env(env_store))
-    assert get_global_response_propagator()
-
-
-def test_server_timing_resp_prop_true():
-    set_global_response_propagator(None)
-    env_store = {"SPLUNK_TRACE_RESPONSE_HEADER_ENABLED": "true"}
-    configure_server_timing_response_propagation(Env(env_store))
-    assert get_global_response_propagator()
-
-
-def test_server_timing_resp_prop_false():
-    set_global_response_propagator(None)
-    env_store = {"SPLUNK_TRACE_RESPONSE_HEADER_ENABLED": "false"}
-    configure_server_timing_response_propagation(Env(env_store))
-    assert get_global_response_propagator() is None
 
 
 def test_profiling_endpt():


### PR DESCRIPTION
PR #788 enabled standard OpenTelemetry declarative configuration. This PR integrates it with the Splunk distro. When OTEL_CONFIG_FILE is set, the distro avoids applying its environment-variable defaults, adds Splunk resource information, and reads the trace response header option from distribution.splunk.

Profiling and callgraphs remain environment-variable only for now. Later PRs will add their declarative configuration.